### PR TITLE
Convert URL Base64 to Base64 before decoding

### DIFF
--- a/src/Nakama/Session.cs
+++ b/src/Nakama/Session.cs
@@ -94,7 +94,7 @@ namespace Nakama
             var payload = jwt.Split('.')[1];
 
             var padLength = Math.Ceiling(payload.Length / 4.0) * 4;
-            payload = payload.PadRight(Convert.ToInt32(padLength), '=');
+            payload = payload.PadRight(Convert.ToInt32(padLength), '=').Replace('-', '+').Replace('_', '/');
 
             return Encoding.UTF8.GetString(Convert.FromBase64String(payload));
         }


### PR DESCRIPTION
## Overview
Currently the decoder that is used on the client only supports Base64 strings and not URLBase64 strings. The only difference between Base64 and URLBase64 is two characters which can be very easily swapped just using `string.Replace()`.

## Todo
- [x] Before passing the payload string (URLBase64) to the Base64 decoder, remove the `-` and `_` characters and use `+` and `/` instead.

## Testing
- [x] Create a user on the server with the username 片仮名, you will not be able to login using the code on master (Base64 decoding exception)
- [x] You are able to login using the code from this fix