### PR TITLE
Fixed sneaky presence drop in SendMatchState

### DIFF
--- a/src/Nakama/WebSocketWrapper.cs
+++ b/src/Nakama/WebSocketWrapper.cs
@@ -66,6 +66,8 @@ namespace Nakama
         /// <inheritdoc />
         public event EventHandler<IStreamState> OnStreamState;
 
+        private static readonly IReadOnlyList<UserPresence> NoPresences = new List<UserPresence>(0);
+
         private readonly Uri _baseUri;
         private readonly WebSocketOptions _options;
         private readonly ConcurrentDictionary<string, TaskCompletionSource<WebSocketMessageEnvelope>> _messageReplies;
@@ -432,7 +434,7 @@ namespace Nakama
                 {
                     MatchId = matchId,
                     OpCode = Convert.ToString(opCode),
-                    Presences = presences as List<UserPresence>,
+                    Presences = BuildPresenceList(presences),
                     State = Convert.ToBase64String(state)
                 }
             };
@@ -454,7 +456,7 @@ namespace Nakama
                 {
                     MatchId = matchId,
                     OpCode = Convert.ToString(opCode),
-                    Presences = presences as List<UserPresence>,
+                    Presences = BuildPresenceList(presences),
                     State = Convert.ToBase64String(state)
                 }
             };
@@ -563,6 +565,27 @@ namespace Nakama
             }
 
             return await resultTask.ConfigureAwait(false);
+        }
+
+        private static List<UserPresence> BuildPresenceList(IEnumerable<IUserPresence> presences)
+        {
+            if(presences == null)
+            {
+                return (List<UserPresence>) NoPresences;
+            }
+
+            List<UserPresence> presenceList = presences as List<UserPresence>;
+            if (presenceList != null)
+            {
+                return presenceList;
+            }
+
+            presenceList =  new List<UserPresence>();
+            foreach(UserPresence concretePresence in presences)
+            {
+                presenceList.Add(concretePresence);
+            }
+            return presenceList;
         }
     }
 }


### PR DESCRIPTION
As _WebSocketWrapper.SendMatchState_ accepts _IEnumerable<IUserPresence>_ one should not assume the underlying type of it (it doesn't even have to be a collection).

For example, passing an array of presences (_IUserPresence[]_) ends up in assigning null presences to the message which is interpreted by the server as "send to all".

With this change type of the parameter is no longer assumed.