### PR TITLE
Fixed deadlock in WebSocketImplementation.Dispose

### DIFF
--- a/src/Nakama/Ninja.WebSockets/Internal/WebSocketImplementation.cs
+++ b/src/Nakama/Ninja.WebSockets/Internal/WebSocketImplementation.cs
@@ -315,7 +315,7 @@ namespace Nakama.Ninja.WebSockets.Internal
                     WebSocketFrameWriter.Write(WebSocketOpCode.ConnectionClose, buffer, stream, true, _isClient);
                     Events.Log.CloseOutputNoHandshake(_guid, closeStatus, statusDescription);
                     Events.Log.SendingFrame(_guid, WebSocketOpCode.ConnectionClose, true, buffer.Count, true);
-                    await WriteStreamToNetwork(stream, cancellationToken);
+                    await WriteStreamToNetwork(stream, cancellationToken).ConfigureAwait(false);
                 }
             }
             else
@@ -341,7 +341,7 @@ namespace Nakama.Ninja.WebSockets.Internal
                     CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
                     try
                     {
-                        CloseOutputAsync(WebSocketCloseStatus.EndpointUnavailable, "Service is Disposed", cts.Token).Wait();
+                        CloseOutputAsync(WebSocketCloseStatus.EndpointUnavailable, "Service is Disposed", cts.Token).Wait(cts.Token);
                     }
                     catch (OperationCanceledException)
                     {


### PR DESCRIPTION
Calling _WebSocketImplementation.Dispose_ on the main thread creates a deadlock.

We're waiting for the task to finish on the main thread (effectively blocking it). At the same time, _WriteStreamToNetwork_ task continuation is dispatched using Unity's synchronization context trying to run on the blocked thread, causing a deadlock.

Adding to the _Wait_ the same cancellation token used for _CloseOutputAsync_ resolves the deadlock after 5 seconds. Forcing the blocking task to continue on different context solves the issue completely.