### PR TITLE
Add Preserve attribute alongside all DataMember attributes

### DIFF
--- a/codegen/main.go
+++ b/codegen/main.go
@@ -131,59 +131,59 @@ namespace Nakama
 
         /// <inheritdoc />
         {{- if eq $property.Type "integer" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public int {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "number" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public double {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "boolean" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public bool {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "string" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public string {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "array" }}
             {{- if eq $property.Items.Type "string" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public List<string> {{ $fieldname }} { get; set; }
             {{- else if eq $property.Items.Type "integer" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public List<int> {{ $fieldname }} { get; set; }
             {{- else if eq $property.Items.Type "number" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public List<double> {{ $fieldname }} { get; set; }
             {{- else if eq $property.Items.Type "boolean" }}
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public List<bool> {{ $fieldname }} { get; set; }
             {{- else}}
         public IEnumerable<I{{ $property.Items.Ref | cleanRef }}> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new List<{{ $property.Items.Ref | cleanRef }}>(0);
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public List<{{ $property.Items.Ref | cleanRef }}> _{{ $propname | camelCase }} { get; set; }
             {{- end }}
         {{- else if eq $property.Type "object"}}
             {{- if eq $property.AdditionalProperties.Type "string"}}
         public IDictionary<string, string> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, string>();
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public Dictionary<string, string> _{{ $propname | camelCase }} { get; set; }
             {{- else if eq $property.Items.Type "integer"}}
         public IDictionary<string, int> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, int>();
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
            {{- else if eq $property.Items.Type "number"}}
         public IDictionary<string, double> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, double>();
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public Dictionary<string, int> _{{ $propname | camelCase }} { get; set; }
             {{- else if eq $property.Items.Type "boolean"}}
         public IDictionary<string, bool> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, bool>();
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public Dictionary<string, bool> _{{ $propname | camelCase }} { get; set; }
             {{- else}}
         public IDictionary<string, {{$property.AdditionalProperties | cleanRef}}> {{ $fieldname }}  => _{{ $propname | camelCase }} ?? new Dictionary<string, {{$property.AdditionalProperties | cleanRef}}>();
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public Dictionary<string, {{$property.AdditionalProperties | cleanRef}}> _{{ $propname | camelCase }} { get; set; }
             {{- end}}
         {{- else }}
         public I{{ $property.Ref | cleanRef }} {{ $fieldname }} => _{{ $propname | camelCase }};
-        [DataMember(Name="{{ $propname }}")]
+        [DataMember(Name="{{ $propname }}"), Preserve]
         public {{ $property.Ref | cleanRef }} _{{ $propname | camelCase }} { get; set; }
         {{- end }}
         {{- end }}

--- a/src/Nakama/ApiClient.gen.cs
+++ b/src/Nakama/ApiClient.gen.cs
@@ -61,12 +61,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="state")]
+        [DataMember(Name="state"), Preserve]
         public int State { get; set; }
 
         /// <inheritdoc />
         public IApiUser User => _user;
-        [DataMember(Name="user")]
+        [DataMember(Name="user"), Preserve]
         public ApiUser _user { get; set; }
 
         public override string ToString()
@@ -101,11 +101,11 @@ namespace Nakama
 
         /// <inheritdoc />
         public IApiGroup Group => _group;
-        [DataMember(Name="group")]
+        [DataMember(Name="group"), Preserve]
         public ApiGroup _group { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="state")]
+        [DataMember(Name="state"), Preserve]
         public int State { get; set; }
 
         public override string ToString()
@@ -144,15 +144,15 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="metadata")]
+        [DataMember(Name="metadata"), Preserve]
         public string Metadata { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="score")]
+        [DataMember(Name="score"), Preserve]
         public string Score { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="subscore")]
+        [DataMember(Name="subscore"), Preserve]
         public string Subscore { get; set; }
 
         public override string ToString()
@@ -192,15 +192,15 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="metadata")]
+        [DataMember(Name="metadata"), Preserve]
         public string Metadata { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="score")]
+        [DataMember(Name="score"), Preserve]
         public string Score { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="subscore")]
+        [DataMember(Name="subscore"), Preserve]
         public string Subscore { get; set; }
 
         public override string ToString()
@@ -260,33 +260,33 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="custom_id")]
+        [DataMember(Name="custom_id"), Preserve]
         public string CustomId { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiAccountDevice> Devices => _devices ?? new List<ApiAccountDevice>(0);
-        [DataMember(Name="devices")]
+        [DataMember(Name="devices"), Preserve]
         public List<ApiAccountDevice> _devices { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="disable_time")]
+        [DataMember(Name="disable_time"), Preserve]
         public string DisableTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="email")]
+        [DataMember(Name="email"), Preserve]
         public string Email { get; set; }
 
         /// <inheritdoc />
         public IApiUser User => _user;
-        [DataMember(Name="user")]
+        [DataMember(Name="user"), Preserve]
         public ApiUser _user { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="verify_time")]
+        [DataMember(Name="verify_time"), Preserve]
         public string VerifyTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="wallet")]
+        [DataMember(Name="wallet"), Preserve]
         public string Wallet { get; set; }
 
         public override string ToString()
@@ -299,6 +299,51 @@ namespace Nakama
             output = string.Concat(output, "User: ", User, ", ");
             output = string.Concat(output, "VerifyTime: ", VerifyTime, ", ");
             output = string.Concat(output, "Wallet: ", Wallet, ", ");
+            return output;
+        }
+    }
+
+    /// <summary>
+    /// Send a Apple Sign In token to the server. Used with authenticate/link/unlink.
+    /// </summary>
+    public interface IApiAccountApple
+    {
+
+        /// <summary>
+        /// The ID token received from Apple to validate.
+        /// </summary>
+        string Token { get; }
+
+        /// <summary>
+        /// Extra information that will be bundled in the session token.
+        /// </summary>
+        IDictionary<string, string> Vars { get; }
+    }
+
+    /// <inheritdoc />
+    internal class ApiAccountApple : IApiAccountApple
+    {
+
+        /// <inheritdoc />
+        [DataMember(Name="token"), Preserve]
+        public string Token { get; set; }
+
+        /// <inheritdoc />
+        public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
+        [DataMember(Name="vars"), Preserve]
+        public Dictionary<string, string> _vars { get; set; }
+
+        public override string ToString()
+        {
+            var output = "";
+            output = string.Concat(output, "Token: ", Token, ", ");
+
+            var mapString = "";
+            foreach (var kvp in Vars)
+            {
+                mapString = string.Concat(mapString, "{" + kvp.Key + "=" + kvp.Value + "}");
+            }
+            output = string.Concat(output, "Vars: [" + mapString + "]");
             return output;
         }
     }
@@ -325,12 +370,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -370,12 +415,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -420,16 +465,16 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="email")]
+        [DataMember(Name="email"), Preserve]
         public string Email { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="password")]
+        [DataMember(Name="password"), Preserve]
         public string Password { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -470,12 +515,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="token")]
+        [DataMember(Name="token"), Preserve]
         public string Token { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -515,12 +560,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="signed_player_info")]
+        [DataMember(Name="signed_player_info"), Preserve]
         public string SignedPlayerInfo { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -585,32 +630,32 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="bundle_id")]
+        [DataMember(Name="bundle_id"), Preserve]
         public string BundleId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="player_id")]
+        [DataMember(Name="player_id"), Preserve]
         public string PlayerId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="public_key_url")]
+        [DataMember(Name="public_key_url"), Preserve]
         public string PublicKeyUrl { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="salt")]
+        [DataMember(Name="salt"), Preserve]
         public string Salt { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="signature")]
+        [DataMember(Name="signature"), Preserve]
         public string Signature { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="timestamp_seconds")]
+        [DataMember(Name="timestamp_seconds"), Preserve]
         public string TimestampSeconds { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -655,12 +700,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="token")]
+        [DataMember(Name="token"), Preserve]
         public string Token { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -700,12 +745,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="token")]
+        [DataMember(Name="token"), Preserve]
         public string Token { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Vars => _vars ?? new Dictionary<string, string>();
-        [DataMember(Name="vars")]
+        [DataMember(Name="vars"), Preserve]
         public Dictionary<string, string> _vars { get; set; }
 
         public override string ToString()
@@ -800,55 +845,55 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="channel_id")]
+        [DataMember(Name="channel_id"), Preserve]
         public string ChannelId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="code")]
+        [DataMember(Name="code"), Preserve]
         public int Code { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="content")]
+        [DataMember(Name="content"), Preserve]
         public string Content { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="create_time")]
+        [DataMember(Name="create_time"), Preserve]
         public string CreateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="group_id")]
+        [DataMember(Name="group_id"), Preserve]
         public string GroupId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="message_id")]
+        [DataMember(Name="message_id"), Preserve]
         public string MessageId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="persistent")]
+        [DataMember(Name="persistent"), Preserve]
         public bool Persistent { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="room_name")]
+        [DataMember(Name="room_name"), Preserve]
         public string RoomName { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="sender_id")]
+        [DataMember(Name="sender_id"), Preserve]
         public string SenderId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="update_time")]
+        [DataMember(Name="update_time"), Preserve]
         public string UpdateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="user_id_one")]
+        [DataMember(Name="user_id_one"), Preserve]
         public string UserIdOne { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="user_id_two")]
+        [DataMember(Name="user_id_two"), Preserve]
         public string UserIdTwo { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="username")]
+        [DataMember(Name="username"), Preserve]
         public string Username { get; set; }
 
         public override string ToString()
@@ -899,15 +944,15 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiChannelMessage> Messages => _messages ?? new List<ApiChannelMessage>(0);
-        [DataMember(Name="messages")]
+        [DataMember(Name="messages"), Preserve]
         public List<ApiChannelMessage> _messages { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="next_cursor")]
+        [DataMember(Name="next_cursor"), Preserve]
         public string NextCursor { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="prev_cursor")]
+        [DataMember(Name="prev_cursor"), Preserve]
         public string PrevCursor { get; set; }
 
         public override string ToString()
@@ -962,27 +1007,27 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="avatar_url")]
+        [DataMember(Name="avatar_url"), Preserve]
         public string AvatarUrl { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="description")]
+        [DataMember(Name="description"), Preserve]
         public string Description { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="lang_tag")]
+        [DataMember(Name="lang_tag"), Preserve]
         public string LangTag { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="max_count")]
+        [DataMember(Name="max_count"), Preserve]
         public int MaxCount { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="name")]
+        [DataMember(Name="name"), Preserve]
         public string Name { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="open")]
+        [DataMember(Name="open"), Preserve]
         public bool Open { get; set; }
 
         public override string ToString()
@@ -1025,15 +1070,15 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="collection")]
+        [DataMember(Name="collection"), Preserve]
         public string Collection { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="key")]
+        [DataMember(Name="key"), Preserve]
         public string Key { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="version")]
+        [DataMember(Name="version"), Preserve]
         public string Version { get; set; }
 
         public override string ToString()
@@ -1064,7 +1109,7 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiDeleteStorageObjectId> ObjectIds => _objectIds ?? new List<ApiDeleteStorageObjectId>(0);
-        [DataMember(Name="object_ids")]
+        [DataMember(Name="object_ids"), Preserve]
         public List<ApiDeleteStorageObjectId> _objectIds { get; set; }
 
         public override string ToString()
@@ -1107,20 +1152,20 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="external")]
+        [DataMember(Name="external"), Preserve]
         public bool External { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="name")]
+        [DataMember(Name="name"), Preserve]
         public string Name { get; set; }
 
         /// <inheritdoc />
         public IDictionary<string, string> Properties => _properties ?? new Dictionary<string, string>();
-        [DataMember(Name="properties")]
+        [DataMember(Name="properties"), Preserve]
         public Dictionary<string, string> _properties { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="timestamp")]
+        [DataMember(Name="timestamp"), Preserve]
         public string Timestamp { get; set; }
 
         public override string ToString()
@@ -1152,6 +1197,11 @@ namespace Nakama
         int State { get; }
 
         /// <summary>
+        /// Time of the latest relationship update.
+        /// </summary>
+        string UpdateTime { get; }
+
+        /// <summary>
         /// The user object.
         /// </summary>
         IApiUser User { get; }
@@ -1162,18 +1212,23 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="state")]
+        [DataMember(Name="state"), Preserve]
         public int State { get; set; }
 
         /// <inheritdoc />
+        [DataMember(Name="update_time"), Preserve]
+        public string UpdateTime { get; set; }
+
+        /// <inheritdoc />
         public IApiUser User => _user;
-        [DataMember(Name="user")]
+        [DataMember(Name="user"), Preserve]
         public ApiUser _user { get; set; }
 
         public override string ToString()
         {
             var output = "";
             output = string.Concat(output, "State: ", State, ", ");
+            output = string.Concat(output, "UpdateTime: ", UpdateTime, ", ");
             output = string.Concat(output, "User: ", User, ", ");
             return output;
         }
@@ -1201,12 +1256,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="cursor")]
+        [DataMember(Name="cursor"), Preserve]
         public string Cursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiFriend> Friends => _friends ?? new List<ApiFriend>(0);
-        [DataMember(Name="friends")]
+        [DataMember(Name="friends"), Preserve]
         public List<ApiFriend> _friends { get; set; }
 
         public override string ToString()
@@ -1290,51 +1345,51 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="avatar_url")]
+        [DataMember(Name="avatar_url"), Preserve]
         public string AvatarUrl { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="create_time")]
+        [DataMember(Name="create_time"), Preserve]
         public string CreateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="creator_id")]
+        [DataMember(Name="creator_id"), Preserve]
         public string CreatorId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="description")]
+        [DataMember(Name="description"), Preserve]
         public string Description { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="edge_count")]
+        [DataMember(Name="edge_count"), Preserve]
         public int EdgeCount { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="lang_tag")]
+        [DataMember(Name="lang_tag"), Preserve]
         public string LangTag { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="max_count")]
+        [DataMember(Name="max_count"), Preserve]
         public int MaxCount { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="metadata")]
+        [DataMember(Name="metadata"), Preserve]
         public string Metadata { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="name")]
+        [DataMember(Name="name"), Preserve]
         public string Name { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="open")]
+        [DataMember(Name="open"), Preserve]
         public bool Open { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="update_time")]
+        [DataMember(Name="update_time"), Preserve]
         public string UpdateTime { get; set; }
 
         public override string ToString()
@@ -1378,12 +1433,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="cursor")]
+        [DataMember(Name="cursor"), Preserve]
         public string Cursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiGroup> Groups => _groups ?? new List<ApiGroup>(0);
-        [DataMember(Name="groups")]
+        [DataMember(Name="groups"), Preserve]
         public List<ApiGroup> _groups { get; set; }
 
         public override string ToString()
@@ -1417,12 +1472,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="cursor")]
+        [DataMember(Name="cursor"), Preserve]
         public string Cursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IGroupUserListGroupUser> GroupUsers => _groupUsers ?? new List<GroupUserListGroupUser>(0);
-        [DataMember(Name="group_users")]
+        [DataMember(Name="group_users"), Preserve]
         public List<GroupUserListGroupUser> _groupUsers { get; set; }
 
         public override string ToString()
@@ -1506,51 +1561,51 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="create_time")]
+        [DataMember(Name="create_time"), Preserve]
         public string CreateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="expiry_time")]
+        [DataMember(Name="expiry_time"), Preserve]
         public string ExpiryTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="leaderboard_id")]
+        [DataMember(Name="leaderboard_id"), Preserve]
         public string LeaderboardId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="max_num_score")]
+        [DataMember(Name="max_num_score"), Preserve]
         public int MaxNumScore { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="metadata")]
+        [DataMember(Name="metadata"), Preserve]
         public string Metadata { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="num_score")]
+        [DataMember(Name="num_score"), Preserve]
         public int NumScore { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="owner_id")]
+        [DataMember(Name="owner_id"), Preserve]
         public string OwnerId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="rank")]
+        [DataMember(Name="rank"), Preserve]
         public string Rank { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="score")]
+        [DataMember(Name="score"), Preserve]
         public string Score { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="subscore")]
+        [DataMember(Name="subscore"), Preserve]
         public string Subscore { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="update_time")]
+        [DataMember(Name="update_time"), Preserve]
         public string UpdateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="username")]
+        [DataMember(Name="username"), Preserve]
         public string Username { get; set; }
 
         public override string ToString()
@@ -1604,21 +1659,21 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="next_cursor")]
+        [DataMember(Name="next_cursor"), Preserve]
         public string NextCursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiLeaderboardRecord> OwnerRecords => _ownerRecords ?? new List<ApiLeaderboardRecord>(0);
-        [DataMember(Name="owner_records")]
+        [DataMember(Name="owner_records"), Preserve]
         public List<ApiLeaderboardRecord> _ownerRecords { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="prev_cursor")]
+        [DataMember(Name="prev_cursor"), Preserve]
         public string PrevCursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiLeaderboardRecord> Records => _records ?? new List<ApiLeaderboardRecord>(0);
-        [DataMember(Name="records")]
+        [DataMember(Name="records"), Preserve]
         public List<ApiLeaderboardRecord> _records { get; set; }
 
         public override string ToString()
@@ -1664,19 +1719,19 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="authoritative")]
+        [DataMember(Name="authoritative"), Preserve]
         public bool Authoritative { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="label")]
+        [DataMember(Name="label"), Preserve]
         public string Label { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="match_id")]
+        [DataMember(Name="match_id"), Preserve]
         public string MatchId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="size")]
+        [DataMember(Name="size"), Preserve]
         public int Size { get; set; }
 
         public override string ToString()
@@ -1708,7 +1763,7 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiMatch> Matches => _matches ?? new List<ApiMatch>(0);
-        [DataMember(Name="matches")]
+        [DataMember(Name="matches"), Preserve]
         public List<ApiMatch> _matches { get; set; }
 
         public override string ToString()
@@ -1766,31 +1821,31 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="code")]
+        [DataMember(Name="code"), Preserve]
         public int Code { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="content")]
+        [DataMember(Name="content"), Preserve]
         public string Content { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="create_time")]
+        [DataMember(Name="create_time"), Preserve]
         public string CreateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="persistent")]
+        [DataMember(Name="persistent"), Preserve]
         public bool Persistent { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="sender_id")]
+        [DataMember(Name="sender_id"), Preserve]
         public string SenderId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="subject")]
+        [DataMember(Name="subject"), Preserve]
         public string Subject { get; set; }
 
         public override string ToString()
@@ -1829,12 +1884,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="cacheable_cursor")]
+        [DataMember(Name="cacheable_cursor"), Preserve]
         public string CacheableCursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiNotification> Notifications => _notifications ?? new List<ApiNotification>(0);
-        [DataMember(Name="notifications")]
+        [DataMember(Name="notifications"), Preserve]
         public List<ApiNotification> _notifications { get; set; }
 
         public override string ToString()
@@ -1873,15 +1928,15 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="collection")]
+        [DataMember(Name="collection"), Preserve]
         public string Collection { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="key")]
+        [DataMember(Name="key"), Preserve]
         public string Key { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="user_id")]
+        [DataMember(Name="user_id"), Preserve]
         public string UserId { get; set; }
 
         public override string ToString()
@@ -1912,7 +1967,7 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiReadStorageObjectId> ObjectIds => _objectIds ?? new List<ApiReadStorageObjectId>(0);
-        [DataMember(Name="object_ids")]
+        [DataMember(Name="object_ids"), Preserve]
         public List<ApiReadStorageObjectId> _objectIds { get; set; }
 
         public override string ToString()
@@ -1950,15 +2005,15 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="http_key")]
+        [DataMember(Name="http_key"), Preserve]
         public string HttpKey { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="payload")]
+        [DataMember(Name="payload"), Preserve]
         public string Payload { get; set; }
 
         public override string ToString()
@@ -1993,11 +2048,11 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="created")]
+        [DataMember(Name="created"), Preserve]
         public bool Created { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="token")]
+        [DataMember(Name="token"), Preserve]
         public string Token { get; set; }
 
         public override string ToString()
@@ -2066,39 +2121,39 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="collection")]
+        [DataMember(Name="collection"), Preserve]
         public string Collection { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="create_time")]
+        [DataMember(Name="create_time"), Preserve]
         public string CreateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="key")]
+        [DataMember(Name="key"), Preserve]
         public string Key { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="permission_read")]
+        [DataMember(Name="permission_read"), Preserve]
         public int PermissionRead { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="permission_write")]
+        [DataMember(Name="permission_write"), Preserve]
         public int PermissionWrite { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="update_time")]
+        [DataMember(Name="update_time"), Preserve]
         public string UpdateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="user_id")]
+        [DataMember(Name="user_id"), Preserve]
         public string UserId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="value")]
+        [DataMember(Name="value"), Preserve]
         public string Value { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="version")]
+        [DataMember(Name="version"), Preserve]
         public string Version { get; set; }
 
         public override string ToString()
@@ -2149,19 +2204,19 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="collection")]
+        [DataMember(Name="collection"), Preserve]
         public string Collection { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="key")]
+        [DataMember(Name="key"), Preserve]
         public string Key { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="user_id")]
+        [DataMember(Name="user_id"), Preserve]
         public string UserId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="version")]
+        [DataMember(Name="version"), Preserve]
         public string Version { get; set; }
 
         public override string ToString()
@@ -2193,7 +2248,7 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiStorageObjectAck> Acks => _acks ?? new List<ApiStorageObjectAck>(0);
-        [DataMember(Name="acks")]
+        [DataMember(Name="acks"), Preserve]
         public List<ApiStorageObjectAck> _acks { get; set; }
 
         public override string ToString()
@@ -2226,12 +2281,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="cursor")]
+        [DataMember(Name="cursor"), Preserve]
         public string Cursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiStorageObject> Objects => _objects ?? new List<ApiStorageObject>(0);
-        [DataMember(Name="objects")]
+        [DataMember(Name="objects"), Preserve]
         public List<ApiStorageObject> _objects { get; set; }
 
         public override string ToString()
@@ -2261,7 +2316,7 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiStorageObject> Objects => _objects ?? new List<ApiStorageObject>(0);
-        [DataMember(Name="objects")]
+        [DataMember(Name="objects"), Preserve]
         public List<ApiStorageObject> _objects { get; set; }
 
         public override string ToString()
@@ -2369,71 +2424,71 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="can_enter")]
+        [DataMember(Name="can_enter"), Preserve]
         public bool CanEnter { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="category")]
+        [DataMember(Name="category"), Preserve]
         public int Category { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="create_time")]
+        [DataMember(Name="create_time"), Preserve]
         public string CreateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="description")]
+        [DataMember(Name="description"), Preserve]
         public string Description { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="duration")]
+        [DataMember(Name="duration"), Preserve]
         public int Duration { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="end_active")]
+        [DataMember(Name="end_active"), Preserve]
         public int EndActive { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="end_time")]
+        [DataMember(Name="end_time"), Preserve]
         public string EndTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="max_num_score")]
+        [DataMember(Name="max_num_score"), Preserve]
         public int MaxNumScore { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="max_size")]
+        [DataMember(Name="max_size"), Preserve]
         public int MaxSize { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="metadata")]
+        [DataMember(Name="metadata"), Preserve]
         public string Metadata { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="next_reset")]
+        [DataMember(Name="next_reset"), Preserve]
         public int NextReset { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="size")]
+        [DataMember(Name="size"), Preserve]
         public int Size { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="sort_order")]
+        [DataMember(Name="sort_order"), Preserve]
         public int SortOrder { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="start_active")]
+        [DataMember(Name="start_active"), Preserve]
         public int StartActive { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="start_time")]
+        [DataMember(Name="start_time"), Preserve]
         public string StartTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="title")]
+        [DataMember(Name="title"), Preserve]
         public string Title { get; set; }
 
         public override string ToString()
@@ -2482,12 +2537,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="cursor")]
+        [DataMember(Name="cursor"), Preserve]
         public string Cursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiTournament> Tournaments => _tournaments ?? new List<ApiTournament>(0);
-        [DataMember(Name="tournaments")]
+        [DataMember(Name="tournaments"), Preserve]
         public List<ApiTournament> _tournaments { get; set; }
 
         public override string ToString()
@@ -2531,21 +2586,21 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="next_cursor")]
+        [DataMember(Name="next_cursor"), Preserve]
         public string NextCursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiLeaderboardRecord> OwnerRecords => _ownerRecords ?? new List<ApiLeaderboardRecord>(0);
-        [DataMember(Name="owner_records")]
+        [DataMember(Name="owner_records"), Preserve]
         public List<ApiLeaderboardRecord> _ownerRecords { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="prev_cursor")]
+        [DataMember(Name="prev_cursor"), Preserve]
         public string PrevCursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IApiLeaderboardRecord> Records => _records ?? new List<ApiLeaderboardRecord>(0);
-        [DataMember(Name="records")]
+        [DataMember(Name="records"), Preserve]
         public List<ApiLeaderboardRecord> _records { get; set; }
 
         public override string ToString()
@@ -2601,27 +2656,27 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="avatar_url")]
+        [DataMember(Name="avatar_url"), Preserve]
         public string AvatarUrl { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="display_name")]
+        [DataMember(Name="display_name"), Preserve]
         public string DisplayName { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="lang_tag")]
+        [DataMember(Name="lang_tag"), Preserve]
         public string LangTag { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="location")]
+        [DataMember(Name="location"), Preserve]
         public string Location { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="timezone")]
+        [DataMember(Name="timezone"), Preserve]
         public string Timezone { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="username")]
+        [DataMember(Name="username"), Preserve]
         public string Username { get; set; }
 
         public override string ToString()
@@ -2679,27 +2734,27 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="avatar_url")]
+        [DataMember(Name="avatar_url"), Preserve]
         public string AvatarUrl { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="description")]
+        [DataMember(Name="description"), Preserve]
         public string Description { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="group_id")]
+        [DataMember(Name="group_id"), Preserve]
         public string GroupId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="lang_tag")]
+        [DataMember(Name="lang_tag"), Preserve]
         public string LangTag { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="name")]
+        [DataMember(Name="name"), Preserve]
         public string Name { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="open")]
+        [DataMember(Name="open"), Preserve]
         public bool Open { get; set; }
 
         public override string ToString()
@@ -2720,6 +2775,11 @@ namespace Nakama
     /// </summary>
     public interface IApiUser
     {
+
+        /// <summary>
+        /// The Apple Sign In ID in the user's account.
+        /// </summary>
+        string AppleId { get; }
 
         /// <summary>
         /// A URL for an avatar image.
@@ -2747,7 +2807,7 @@ namespace Nakama
         string FacebookId { get; }
 
         /// <summary>
-        /// The Facebook Instant Game id in the user's account.
+        /// The Facebook Instant Game ID in the user's account.
         /// </summary>
         string FacebookInstantGameId { get; }
 
@@ -2812,76 +2872,81 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="avatar_url")]
+        [DataMember(Name="apple_id"), Preserve]
+        public string AppleId { get; set; }
+
+        /// <inheritdoc />
+        [DataMember(Name="avatar_url"), Preserve]
         public string AvatarUrl { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="create_time")]
+        [DataMember(Name="create_time"), Preserve]
         public string CreateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="display_name")]
+        [DataMember(Name="display_name"), Preserve]
         public string DisplayName { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="edge_count")]
+        [DataMember(Name="edge_count"), Preserve]
         public int EdgeCount { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="facebook_id")]
+        [DataMember(Name="facebook_id"), Preserve]
         public string FacebookId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="facebook_instant_game_id")]
+        [DataMember(Name="facebook_instant_game_id"), Preserve]
         public string FacebookInstantGameId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="gamecenter_id")]
+        [DataMember(Name="gamecenter_id"), Preserve]
         public string GamecenterId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="google_id")]
+        [DataMember(Name="google_id"), Preserve]
         public string GoogleId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="lang_tag")]
+        [DataMember(Name="lang_tag"), Preserve]
         public string LangTag { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="location")]
+        [DataMember(Name="location"), Preserve]
         public string Location { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="metadata")]
+        [DataMember(Name="metadata"), Preserve]
         public string Metadata { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="online")]
+        [DataMember(Name="online"), Preserve]
         public bool Online { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="steam_id")]
+        [DataMember(Name="steam_id"), Preserve]
         public string SteamId { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="timezone")]
+        [DataMember(Name="timezone"), Preserve]
         public string Timezone { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="update_time")]
+        [DataMember(Name="update_time"), Preserve]
         public string UpdateTime { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="username")]
+        [DataMember(Name="username"), Preserve]
         public string Username { get; set; }
 
         public override string ToString()
         {
             var output = "";
+            output = string.Concat(output, "AppleId: ", AppleId, ", ");
             output = string.Concat(output, "AvatarUrl: ", AvatarUrl, ", ");
             output = string.Concat(output, "CreateTime: ", CreateTime, ", ");
             output = string.Concat(output, "DisplayName: ", DisplayName, ", ");
@@ -2925,12 +2990,12 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="cursor")]
+        [DataMember(Name="cursor"), Preserve]
         public string Cursor { get; set; }
 
         /// <inheritdoc />
         public IEnumerable<IUserGroupListUserGroup> UserGroups => _userGroups ?? new List<UserGroupListUserGroup>(0);
-        [DataMember(Name="user_groups")]
+        [DataMember(Name="user_groups"), Preserve]
         public List<UserGroupListUserGroup> _userGroups { get; set; }
 
         public override string ToString()
@@ -2960,7 +3025,7 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiUser> Users => _users ?? new List<ApiUser>(0);
-        [DataMember(Name="users")]
+        [DataMember(Name="users"), Preserve]
         public List<ApiUser> _users { get; set; }
 
         public override string ToString()
@@ -3013,27 +3078,27 @@ namespace Nakama
     {
 
         /// <inheritdoc />
-        [DataMember(Name="collection")]
+        [DataMember(Name="collection"), Preserve]
         public string Collection { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="key")]
+        [DataMember(Name="key"), Preserve]
         public string Key { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="permission_read")]
+        [DataMember(Name="permission_read"), Preserve]
         public int PermissionRead { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="permission_write")]
+        [DataMember(Name="permission_write"), Preserve]
         public int PermissionWrite { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="value")]
+        [DataMember(Name="value"), Preserve]
         public string Value { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="version")]
+        [DataMember(Name="version"), Preserve]
         public string Version { get; set; }
 
         public override string ToString()
@@ -3067,13 +3132,110 @@ namespace Nakama
 
         /// <inheritdoc />
         public IEnumerable<IApiWriteStorageObject> Objects => _objects ?? new List<ApiWriteStorageObject>(0);
-        [DataMember(Name="objects")]
+        [DataMember(Name="objects"), Preserve]
         public List<ApiWriteStorageObject> _objects { get; set; }
 
         public override string ToString()
         {
             var output = "";
             output = string.Concat(output, "Objects: [", string.Join(", ", Objects), "], ");
+            return output;
+        }
+    }
+
+    /// <summary>
+    /// `Any` contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.  Protobuf library provides support to pack/unpack Any values in the form of utility functions or additional generated methods of the Any type.  Example 1: Pack and unpack a message in C++.      Foo foo = ...;     Any any;     any.PackFrom(foo);     ...     if (any.UnpackTo(&foo)) {       ...     }  Example 2: Pack and unpack a message in Java.      Foo foo = ...;     Any any = Any.pack(foo);     ...     if (any.is(Foo.class)) {       foo = any.unpack(Foo.class);     }   Example 3: Pack and unpack a message in Python.      foo = Foo(...)     any = Any()     any.Pack(foo)     ...     if any.Is(Foo.DESCRIPTOR):       any.Unpack(foo)       ...   Example 4: Pack and unpack a message in Go       foo := &pb.Foo{...}      any, err := ptypes.MarshalAny(foo)      ...      foo := &pb.Foo{}      if err := ptypes.UnmarshalAny(any, foo); err != nil {        ...      }  The pack methods provided by protobuf library will by default use 'type.googleapis.com/full.type.name' as the type URL and the unpack methods only use the fully qualified type name after the last '/' in the type URL, for example "foo.bar.com/x/y.z" will yield type name "y.z".   JSON ==== The JSON representation of an `Any` value uses the regular representation of the deserialized, embedded message, with an additional field `@type` which contains the type URL. Example:      package google.profile;     message Person {       string first_name = 1;       string last_name = 2;     }      {       "@type": "type.googleapis.com/google.profile.Person",       "firstName": <string>,       "lastName": <string>     }  If the embedded message type is well-known and has a custom JSON representation, that representation will be embedded adding a field `value` which holds the custom JSON in addition to the `@type` field. Example (for message [google.protobuf.Duration][]):      {       "@type": "type.googleapis.com/google.protobuf.Duration",       "value": "1.212s"     }
+    /// </summary>
+    public interface IProtobufAny
+    {
+
+        /// <summary>
+        /// A URL/resource name that uniquely identifies the type of the serialized protocol buffer message. This string must contain at least one "/" character. The last segment of the URL's path must represent the fully qualified name of the type (as in `path/google.protobuf.Duration`). The name should be in a canonical form (e.g., leading "." is not accepted).  In practice, teams usually precompile into the binary all types that they expect it to use in the context of Any. However, for URLs which use the scheme `http`, `https`, or no scheme, one can optionally set up a type server that maps type URLs to message definitions as follows:  * If no scheme is provided, `https` is assumed. * An HTTP GET on the URL must yield a [google.protobuf.Type][]   value in binary format, or produce an error. * Applications are allowed to cache lookup results based on the   URL, or have them precompiled into a binary to avoid any   lookup. Therefore, binary compatibility needs to be preserved   on changes to types. (Use versioned type names to manage   breaking changes.)  Note: this functionality is not currently available in the official protobuf release, and it is not used for type URLs beginning with type.googleapis.com.  Schemes other than `http`, `https` (or the empty scheme) might be used with implementation specific semantics.
+        /// </summary>
+        string TypeUrl { get; }
+
+        /// <summary>
+        /// Must be a valid serialized protocol buffer of the above specified type.
+        /// </summary>
+        string Value { get; }
+    }
+
+    /// <inheritdoc />
+    internal class ProtobufAny : IProtobufAny
+    {
+
+        /// <inheritdoc />
+        [DataMember(Name="type_url"), Preserve]
+        public string TypeUrl { get; set; }
+
+        /// <inheritdoc />
+        [DataMember(Name="value"), Preserve]
+        public string Value { get; set; }
+
+        public override string ToString()
+        {
+            var output = "";
+            output = string.Concat(output, "TypeUrl: ", TypeUrl, ", ");
+            output = string.Concat(output, "Value: ", Value, ", ");
+            return output;
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IRuntimeError
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        int Code { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        IEnumerable<IProtobufAny> Details { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        string Error { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        string Message { get; }
+    }
+
+    /// <inheritdoc />
+    internal class RuntimeError : IRuntimeError
+    {
+
+        /// <inheritdoc />
+        [DataMember(Name="code"), Preserve]
+        public int Code { get; set; }
+
+        /// <inheritdoc />
+        public IEnumerable<IProtobufAny> Details => _details ?? new List<ProtobufAny>(0);
+        [DataMember(Name="details"), Preserve]
+        public List<ProtobufAny> _details { get; set; }
+
+        /// <inheritdoc />
+        [DataMember(Name="error"), Preserve]
+        public string Error { get; set; }
+
+        /// <inheritdoc />
+        [DataMember(Name="message"), Preserve]
+        public string Message { get; set; }
+
+        public override string ToString()
+        {
+            var output = "";
+            output = string.Concat(output, "Code: ", Code, ", ");
+            output = string.Concat(output, "Details: [", string.Join(", ", Details), "], ");
+            output = string.Concat(output, "Error: ", Error, ", ");
+            output = string.Concat(output, "Message: ", Message, ", ");
             return output;
         }
     }
@@ -3178,6 +3340,42 @@ namespace Nakama
             var jsonBody = body.ToJson();
             content = Encoding.UTF8.GetBytes(jsonBody);
             await HttpAdapter.SendAsync(method, uri, headers, content, _timeout);
+        }
+
+        /// <summary>
+        /// Authenticate a user with an Apple ID against the server.
+        /// </summary>
+        public async Task<IApiSession> AuthenticateAppleAsync(
+            string basicAuthUsername,
+            string basicAuthPassword,
+            ApiAccountApple body)
+        {
+            if (body == null)
+            {
+                throw new ArgumentException("'body' is required but was null.");
+            }
+
+            var urlpath = "/v2/account/authenticate/apple";
+
+            var queryParams = "";
+
+            var uri = new UriBuilder(_baseUri)
+            {
+                Path = urlpath,
+                Query = queryParams
+            }.Uri;
+
+            var method = "POST";
+            var headers = new Dictionary<string, string>();
+            var credentials = Encoding.UTF8.GetBytes(basicAuthUsername + ":" + basicAuthPassword);
+            var header = string.Concat("Basic ", Convert.ToBase64String(credentials));
+            headers.Add("Authorization", header);
+
+            byte[] content = null;
+            var jsonBody = body.ToJson();
+            content = Encoding.UTF8.GetBytes(jsonBody);
+            var contents = await HttpAdapter.SendAsync(method, uri, headers, content, _timeout);
+            return contents.FromJson<ApiSession>();
         }
 
         /// <summary>
@@ -3537,6 +3735,39 @@ namespace Nakama
         }
 
         /// <summary>
+        /// Add an Apple ID to the social profiles on the current user's account.
+        /// </summary>
+        public async Task LinkAppleAsync(
+            string bearerToken,
+            ApiAccountApple body)
+        {
+            if (body == null)
+            {
+                throw new ArgumentException("'body' is required but was null.");
+            }
+
+            var urlpath = "/v2/account/link/apple";
+
+            var queryParams = "";
+
+            var uri = new UriBuilder(_baseUri)
+            {
+                Path = urlpath,
+                Query = queryParams
+            }.Uri;
+
+            var method = "POST";
+            var headers = new Dictionary<string, string>();
+            var header = string.Concat("Bearer ", bearerToken);
+            headers.Add("Authorization", header);
+
+            byte[] content = null;
+            var jsonBody = body.ToJson();
+            content = Encoding.UTF8.GetBytes(jsonBody);
+            await HttpAdapter.SendAsync(method, uri, headers, content, _timeout);
+        }
+
+        /// <summary>
         /// Add a custom ID to the social profiles on the current user's account.
         /// </summary>
         public async Task LinkCustomAsync(
@@ -3784,6 +4015,39 @@ namespace Nakama
             }
 
             var urlpath = "/v2/account/link/steam";
+
+            var queryParams = "";
+
+            var uri = new UriBuilder(_baseUri)
+            {
+                Path = urlpath,
+                Query = queryParams
+            }.Uri;
+
+            var method = "POST";
+            var headers = new Dictionary<string, string>();
+            var header = string.Concat("Bearer ", bearerToken);
+            headers.Add("Authorization", header);
+
+            byte[] content = null;
+            var jsonBody = body.ToJson();
+            content = Encoding.UTF8.GetBytes(jsonBody);
+            await HttpAdapter.SendAsync(method, uri, headers, content, _timeout);
+        }
+
+        /// <summary>
+        /// Remove the Apple ID from the social profiles on the current user's account.
+        /// </summary>
+        public async Task UnlinkAppleAsync(
+            string bearerToken,
+            ApiAccountApple body)
+        {
+            if (body == null)
+            {
+                throw new ArgumentException("'body' is required but was null.");
+            }
+
+            var urlpath = "/v2/account/unlink/apple";
 
             var queryParams = "";
 
@@ -4525,6 +4789,47 @@ namespace Nakama
             }
 
             var urlpath = "/v2/group/{group_id}/ban";
+            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+
+            var queryParams = "";
+            foreach (var elem in userIds ?? new string[0])
+            {
+                queryParams = string.Concat(queryParams, "user_ids=", elem, "&");
+            }
+
+            var uri = new UriBuilder(_baseUri)
+            {
+                Path = urlpath,
+                Query = queryParams
+            }.Uri;
+
+            var method = "POST";
+            var headers = new Dictionary<string, string>();
+            var header = string.Concat("Bearer ", bearerToken);
+            headers.Add("Authorization", header);
+
+            byte[] content = null;
+            await HttpAdapter.SendAsync(method, uri, headers, content, _timeout);
+        }
+
+        /// <summary>
+        /// Demote a set of users in a group to the next role down.
+        /// </summary>
+        public async Task DemoteGroupUsersAsync(
+            string bearerToken,
+            string groupId,
+            IEnumerable<string> userIds)
+        {
+            if (groupId == null)
+            {
+                throw new ArgumentException("'groupId' is required but was null.");
+            }
+            if (userIds == null)
+            {
+                throw new ArgumentException("'userIds' is required but was null.");
+            }
+
+            var urlpath = "/v2/group/{group_id}/demote";
             urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";

--- a/src/Nakama/ChannelJoinMessage.cs
+++ b/src/Nakama/ChannelJoinMessage.cs
@@ -23,16 +23,16 @@ namespace Nakama
     /// </summary>
     internal class ChannelJoinMessage
     {
-        [DataMember(Name="hidden")]
+        [DataMember(Name="hidden"), Preserve]
         public bool Hidden { get; set; }
-        
-        [DataMember(Name="persistence")]
+
+        [DataMember(Name="persistence"), Preserve]
         public bool Persistence { get; set; }
-        
-        [DataMember(Name="target")]
+
+        [DataMember(Name="target"), Preserve]
         public string Target { get; set; }
-        
-        [DataMember(Name="type")]
+
+        [DataMember(Name="type"), Preserve]
         public int Type { get; set; }
 
         public override string ToString()

--- a/src/Nakama/ChannelLeaveMessage.cs
+++ b/src/Nakama/ChannelLeaveMessage.cs
@@ -23,7 +23,7 @@ namespace Nakama
     /// </summary>
     internal class ChannelLeaveMessage
     {
-        [DataMember(Name="channel_id")]
+        [DataMember(Name="channel_id"), Preserve]
         public string ChannelId { get; set; }
 
         public override string ToString()

--- a/src/Nakama/ChannelRemoveMessage.cs
+++ b/src/Nakama/ChannelRemoveMessage.cs
@@ -23,10 +23,10 @@ namespace Nakama
     /// </summary>
     internal class ChannelRemoveMessage
     {
-        [DataMember(Name="channel_id")]
+        [DataMember(Name="channel_id"), Preserve]
         public string ChannelId { get; set; }
 
-        [DataMember(Name="message_id")]
+        [DataMember(Name="message_id"), Preserve]
         public string MessageId { get; set; }
 
         public override string ToString()

--- a/src/Nakama/ChannelSendMessage.cs
+++ b/src/Nakama/ChannelSendMessage.cs
@@ -23,10 +23,10 @@ namespace Nakama
     /// </summary>
     internal class ChannelSendMessage
     {
-        [DataMember(Name="channel_id")]
+        [DataMember(Name="channel_id"), Preserve]
         public string ChannelId { get; set; }
 
-        [DataMember(Name="content")]
+        [DataMember(Name="content"), Preserve]
         public string Content { get; set; }
 
         public override string ToString()

--- a/src/Nakama/ChannelUpdateMessage.cs
+++ b/src/Nakama/ChannelUpdateMessage.cs
@@ -23,13 +23,13 @@ namespace Nakama
     /// </summary>
     internal class ChannelUpdateMessage
     {
-        [DataMember(Name="channel_id")]
+        [DataMember(Name="channel_id"), Preserve]
         public string ChannelId { get; set; }
 
-        [DataMember(Name="message_id")]
+        [DataMember(Name="message_id"), Preserve]
         public string MessageId { get; set; }
 
-        [DataMember(Name="content")]
+        [DataMember(Name="content"), Preserve]
         public string Content { get; set; }
 
         public override string ToString()

--- a/src/Nakama/IChannel.cs
+++ b/src/Nakama/IChannel.cs
@@ -38,22 +38,22 @@ namespace Nakama
         /// The presence of the current user. i.e. Your self.
         /// </summary>
         IUserPresence Self { get; }
-        
+
         /// <summary>
         /// The name of the chat room, or an empty string if this message was not sent through a chat room.
         /// </summary>
         string RoomName { get; }
-        
+
         /// <summary>
         /// The ID of the group, or an empty string if this message was not sent through a group channel.
         /// </summary>
         string GroupId { get; }
-        
+
         /// <summary>
         /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
         /// </summary>
         string UserIdOne { get; }
-        
+
         /// <summary>
         /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
         /// </summary>
@@ -63,27 +63,27 @@ namespace Nakama
     /// <inheritdoc cref="IChannel"/>
     internal class Channel : IChannel
     {
-        [DataMember(Name="id")]
+        [DataMember(Name="id"), Preserve]
         public string Id { get; set; }
 
         public IEnumerable<IUserPresence> Presences => _presences ?? UserPresence.NoPresences;
-        [DataMember(Name="presences")]
+        [DataMember(Name="presences"), Preserve]
         public List<UserPresence> _presences { get; set; }
 
         public IUserPresence Self => _self;
-        [DataMember(Name="self")]
+        [DataMember(Name="self"), Preserve]
         public UserPresence _self { get; set; }
-        
-        [DataMember(Name="room_name")]
+
+        [DataMember(Name="room_name"), Preserve]
         public string RoomName { get; set; }
-        
-        [DataMember(Name="group_id")]
+
+        [DataMember(Name="group_id"), Preserve]
         public string GroupId { get; set; }
-        
-        [DataMember(Name="user_id_one")]
+
+        [DataMember(Name="user_id_one"), Preserve]
         public string UserIdOne { get; set; }
-        
-        [DataMember(Name="user_id_two")]
+
+        [DataMember(Name="user_id_two"), Preserve]
         public string UserIdTwo { get; set; }
 
         public override bool Equals(object obj)

--- a/src/Nakama/IChannelMessageAck.cs
+++ b/src/Nakama/IChannelMessageAck.cs
@@ -57,22 +57,22 @@ namespace Nakama
         /// The username of the sender of the message.
         /// </summary>
         string Username { get; }
-        
+
         /// <summary>
         /// The name of the chat room, or an empty string if this message was not sent through a chat room.
         /// </summary>
         string RoomName { get; }
-        
+
         /// <summary>
         /// The ID of the group, or an empty string if this message was not sent through a group channel.
         /// </summary>
         string GroupId { get; }
-        
+
         /// <summary>
         /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
         /// </summary>
         string UserIdOne { get; }
-        
+
         /// <summary>
         /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
         /// </summary>
@@ -82,27 +82,27 @@ namespace Nakama
     /// <inheritdoc cref="IChannelMessageAck"/>
     internal class ChannelMessageAck : IChannelMessageAck
     {
-        [DataMember(Name = "channel_id")] public string ChannelId { get; set; }
+        [DataMember(Name = "channel_id"), Preserve] public string ChannelId { get; set; }
 
-        [DataMember(Name = "code")] public int Code { get; set; }
+        [DataMember(Name = "code"), Preserve] public int Code { get; set; }
 
-        [DataMember(Name = "create_time")] public string CreateTime { get; set; }
+        [DataMember(Name = "create_time"), Preserve] public string CreateTime { get; set; }
 
-        [DataMember(Name = "message_id")] public string MessageId { get; set; }
+        [DataMember(Name = "message_id"), Preserve] public string MessageId { get; set; }
 
-        [DataMember(Name = "persistent")] public bool Persistent { get; set; }
+        [DataMember(Name = "persistent"), Preserve] public bool Persistent { get; set; }
 
-        [DataMember(Name = "update_time")] public string UpdateTime { get; set; }
+        [DataMember(Name = "update_time"), Preserve] public string UpdateTime { get; set; }
 
-        [DataMember(Name = "username")] public string Username { get; set; }
-        
-        [DataMember(Name="room_name")] public string RoomName { get; set; }
-        
-        [DataMember(Name="group_id")] public string GroupId { get; set; }
-        
-        [DataMember(Name="user_id_one")] public string UserIdOne { get; set; }
-        
-        [DataMember(Name="user_id_two")] public string UserIdTwo { get; set; }
+        [DataMember(Name = "username"), Preserve] public string Username { get; set; }
+
+        [DataMember(Name="room_name"), Preserve] public string RoomName { get; set; }
+
+        [DataMember(Name="group_id"), Preserve] public string GroupId { get; set; }
+
+        [DataMember(Name="user_id_one"), Preserve] public string UserIdOne { get; set; }
+
+        [DataMember(Name="user_id_two"), Preserve] public string UserIdTwo { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/IChannelPresenceEvent.cs
+++ b/src/Nakama/IChannelPresenceEvent.cs
@@ -43,17 +43,17 @@ namespace Nakama
         /// The name of the chat room, or an empty string if this message was not sent through a chat room.
         /// </summary>
         string RoomName { get; }
-        
+
         /// <summary>
         /// The ID of the group, or an empty string if this message was not sent through a group channel.
         /// </summary>
         string GroupId { get; }
-        
+
         /// <summary>
         /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
         /// </summary>
         string UserIdOne { get; }
-        
+
         /// <summary>
         /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
         /// </summary>
@@ -63,27 +63,27 @@ namespace Nakama
     /// <inheritdoc cref="IChannelPresenceEvent"/>
     internal class ChannelPresenceEvent : IChannelPresenceEvent
     {
-        [DataMember(Name="channel_id")]
+        [DataMember(Name="channel_id"), Preserve]
         public string ChannelId { get; set; }
 
         public IEnumerable<IUserPresence> Joins => _joins ?? new List<UserPresence>(0);
-        [DataMember(Name="joins")]
+        [DataMember(Name="joins"), Preserve]
         public List<UserPresence> _joins { get; set; }
 
         public IEnumerable<IUserPresence> Leaves => _leaves ?? new List<UserPresence>(0);
-        [DataMember(Name="leaves")]
+        [DataMember(Name="leaves"), Preserve]
         public List<UserPresence> _leaves { get; set; }
-        
-        [DataMember(Name="room_name")]
+
+        [DataMember(Name="room_name"), Preserve]
         public string RoomName { get; set; }
-        
-        [DataMember(Name="group_id")]
+
+        [DataMember(Name="group_id"), Preserve]
         public string GroupId { get; set; }
-        
-        [DataMember(Name="user_id_one")]
+
+        [DataMember(Name="user_id_one"), Preserve]
         public string UserIdOne { get; set; }
-        
-        [DataMember(Name="user_id_two")]
+
+        [DataMember(Name="user_id_two"), Preserve]
         public string UserIdTwo { get; set; }
 
         public override string ToString()

--- a/src/Nakama/IMatch.cs
+++ b/src/Nakama/IMatch.cs
@@ -58,19 +58,19 @@ namespace Nakama
     /// <inheritdoc cref="IMatch"/>
     internal class Match : IMatch
     {
-        [DataMember(Name = "authoritative")] public bool Authoritative { get; set; }
+        [DataMember(Name = "authoritative"), Preserve] public bool Authoritative { get; set; }
 
-        [DataMember(Name = "match_id")] public string Id { get; set; }
+        [DataMember(Name = "match_id"), Preserve] public string Id { get; set; }
 
-        [DataMember(Name = "label")] public string Label { get; set; }
+        [DataMember(Name = "label"), Preserve] public string Label { get; set; }
 
         public IEnumerable<IUserPresence> Presences => _presences ?? UserPresence.NoPresences;
-        [DataMember(Name = "presences")] public List<UserPresence> _presences { get; set; }
+        [DataMember(Name = "presences"), Preserve] public List<UserPresence> _presences { get; set; }
 
-        [DataMember(Name = "size")] public int Size { get; set; }
+        [DataMember(Name = "size"), Preserve] public int Size { get; set; }
 
         public IUserPresence Self => _self;
-        [DataMember(Name = "self")] public UserPresence _self { get; set; }
+        [DataMember(Name = "self"), Preserve] public UserPresence _self { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/IMatchPresenceEvent.cs
+++ b/src/Nakama/IMatchPresenceEvent.cs
@@ -44,12 +44,12 @@ namespace Nakama
     internal class MatchPresenceEvent : IMatchPresenceEvent
     {
         public IEnumerable<IUserPresence> Joins => _joins ?? UserPresence.NoPresences;
-        [DataMember(Name = "joins")] public List<UserPresence> _joins { get; set; }
+        [DataMember(Name = "joins"), Preserve] public List<UserPresence> _joins { get; set; }
 
         public IEnumerable<IUserPresence> Leaves => _leaves ?? UserPresence.NoPresences;
-        [DataMember(Name = "leaves")] public List<UserPresence> _leaves { get; set; }
+        [DataMember(Name = "leaves"), Preserve] public List<UserPresence> _leaves { get; set; }
 
-        [DataMember(Name = "match_id")] public string MatchId { get; set; }
+        [DataMember(Name = "match_id"), Preserve] public string MatchId { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/IMatchState.cs
+++ b/src/Nakama/IMatchState.cs
@@ -53,16 +53,16 @@ namespace Nakama
     {
         private static readonly byte[] NoBytes = new byte[0];
 
-        [DataMember(Name = "match_id")] public string MatchId { get; set; }
+        [DataMember(Name = "match_id"), Preserve] public string MatchId { get; set; }
 
         public long OpCode => Convert.ToInt64(_opCode);
-        [DataMember(Name = "op_code")] public string _opCode { get; set; }
+        [DataMember(Name = "op_code"), Preserve] public string _opCode { get; set; }
 
         public byte[] State => _state == null ? NoBytes :  Convert.FromBase64String(_state);
-        [DataMember(Name = "data")] public string _state { get; set; }
+        [DataMember(Name = "data"), Preserve] public string _state { get; set; }
 
         public IUserPresence UserPresence => _userPresence;
-        [DataMember(Name = "presence")] public UserPresence _userPresence { get; set; }
+        [DataMember(Name = "presence"), Preserve] public UserPresence _userPresence { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/IMatchmakerMatched.cs
+++ b/src/Nakama/IMatchmakerMatched.cs
@@ -77,17 +77,17 @@ namespace Nakama
     /// <inheritdoc cref="IMatchmakerMatched"/>
     internal class MatchmakerMatched : IMatchmakerMatched
     {
-        [DataMember(Name = "match_id")] public string MatchId { get; set; }
+        [DataMember(Name = "match_id"), Preserve] public string MatchId { get; set; }
 
-        [DataMember(Name = "ticket")] public string Ticket { get; set; }
+        [DataMember(Name = "ticket"), Preserve] public string Ticket { get; set; }
 
-        [DataMember(Name = "token")] public string Token { get; set; }
+        [DataMember(Name = "token"), Preserve] public string Token { get; set; }
 
         public IEnumerable<IMatchmakerUser> Users => _users ?? new List<MatchmakerUser>(0);
-        [DataMember(Name = "users")] public List<MatchmakerUser> _users { get; set; }
+        [DataMember(Name = "users"), Preserve] public List<MatchmakerUser> _users { get; set; }
 
         public IMatchmakerUser Self => _self;
-        [DataMember(Name = "self")] public MatchmakerUser _self { get; set; }
+        [DataMember(Name = "self"), Preserve] public MatchmakerUser _self { get; set; }
 
         public override string ToString()
         {
@@ -102,15 +102,15 @@ namespace Nakama
     {
         public IDictionary<string, double> NumericProperties => _numericProperties ?? new Dictionary<string, double>();
 
-        [DataMember(Name = "numeric_properties")]
+        [DataMember(Name = "numeric_properties"), Preserve]
         public Dictionary<string, double> _numericProperties { get; set; }
 
         public IUserPresence Presence => _presence;
-        [DataMember(Name = "presence")] public UserPresence _presence { get; set; }
+        [DataMember(Name = "presence"), Preserve] public UserPresence _presence { get; set; }
 
         public IDictionary<string, string> StringProperties => _stringProperties ?? new Dictionary<string, string>();
 
-        [DataMember(Name = "string_properties")]
+        [DataMember(Name = "string_properties"), Preserve]
         public Dictionary<string, string> _stringProperties { get; set; }
 
         public override string ToString()

--- a/src/Nakama/IMatchmakerTicket.cs
+++ b/src/Nakama/IMatchmakerTicket.cs
@@ -32,7 +32,7 @@ namespace Nakama
     /// <inheritdoc cref="IMatchmakerMatched"/>
     internal class MatchmakerTicket : IMatchmakerTicket
     {
-        [DataMember(Name="ticket")]
+        [DataMember(Name="ticket"), Preserve]
         public string Ticket { get; set; }
 
         public override string ToString()

--- a/src/Nakama/IStatus.cs
+++ b/src/Nakama/IStatus.cs
@@ -34,7 +34,7 @@ namespace Nakama
     internal class Status : IStatus
     {
         public IEnumerable<IUserPresence> Presences => _presences ?? UserPresence.NoPresences;
-        [DataMember(Name="presences")]
+        [DataMember(Name="presences"), Preserve]
         public List<UserPresence> _presences { get; set; }
 
         public override string ToString()

--- a/src/Nakama/IStatusPresenceEvent.cs
+++ b/src/Nakama/IStatusPresenceEvent.cs
@@ -45,10 +45,10 @@ namespace Nakama
     internal class StatusPresenceEvent : IStatusPresenceEvent
     {
         public IEnumerable<IUserPresence> Leaves => _leaves ?? UserPresence.NoPresences;
-        [DataMember(Name = "leaves")] public List<UserPresence> _leaves { get; set; }
+        [DataMember(Name = "leaves"), Preserve] public List<UserPresence> _leaves { get; set; }
 
         public IEnumerable<IUserPresence> Joins => _joins ?? UserPresence.NoPresences;
-        [DataMember(Name = "joins")] public List<UserPresence> _joins { get; set; }
+        [DataMember(Name = "joins"), Preserve] public List<UserPresence> _joins { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/IStreamPresenceEvent.cs
+++ b/src/Nakama/IStreamPresenceEvent.cs
@@ -95,13 +95,13 @@ namespace Nakama
     internal class StreamPresenceEvent : IStreamPresenceEvent
     {
         public IEnumerable<IUserPresence> Leaves => _leaves ?? UserPresence.NoPresences;
-        [DataMember(Name = "leaves")] public List<UserPresence> _leaves { get; set; }
+        [DataMember(Name = "leaves"), Preserve] public List<UserPresence> _leaves { get; set; }
 
         public IEnumerable<IUserPresence> Joins => _joins ?? UserPresence.NoPresences;
-        [DataMember(Name = "joins")] public List<UserPresence> _joins { get; set; }
+        [DataMember(Name = "joins"), Preserve] public List<UserPresence> _joins { get; set; }
 
         public IStream Stream => _stream;
-        [DataMember(Name = "stream")] public Stream _stream { get; set; }
+        [DataMember(Name = "stream"), Preserve] public Stream _stream { get; set; }
 
         public override string ToString()
         {
@@ -115,13 +115,13 @@ namespace Nakama
     internal class StreamState : IStreamState
     {
         public IUserPresence Sender => _sender;
-        [DataMember(Name = "sender")] public UserPresence _sender { get; set; }
+        [DataMember(Name = "sender"), Preserve] public UserPresence _sender { get; set; }
 
         public string State => _state;
-        [DataMember(Name = "data")] public string _state { get; set; }
+        [DataMember(Name = "data"), Preserve] public string _state { get; set; }
 
         public IStream Stream => _stream;
-        [DataMember(Name = "stream")] public Stream _stream { get; set; }
+        [DataMember(Name = "stream"), Preserve] public Stream _stream { get; set; }
 
         public override string ToString()
         {
@@ -132,13 +132,13 @@ namespace Nakama
     /// <inheritdoc cref="IStream"/>
     internal class Stream : IStream
     {
-        [DataMember(Name = "descriptor")] public string Descriptor { get; set; }
+        [DataMember(Name = "descriptor"), Preserve] public string Descriptor { get; set; }
 
-        [DataMember(Name = "label")] public string Label { get; set; }
+        [DataMember(Name = "label"), Preserve] public string Label { get; set; }
 
-        [DataMember(Name = "mode")] public int Mode { get; set; }
+        [DataMember(Name = "mode"), Preserve] public int Mode { get; set; }
 
-        [DataMember(Name = "subject")] public string Subject { get; set; }
+        [DataMember(Name = "subject"), Preserve] public string Subject { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/IUserPresence.cs
+++ b/src/Nakama/IUserPresence.cs
@@ -59,15 +59,15 @@ namespace Nakama
     {
         internal static readonly IReadOnlyList<UserPresence> NoPresences = new List<UserPresence>(0);
 
-        [DataMember(Name = "persistence")] public bool Persistence { get; set; }
+        [DataMember(Name = "persistence"), Preserve] public bool Persistence { get; set; }
 
-        [DataMember(Name = "session_id")] public string SessionId { get; set; }
+        [DataMember(Name = "session_id"), Preserve] public string SessionId { get; set; }
 
-        [DataMember(Name = "status")] public string Status { get; set; }
+        [DataMember(Name = "status"), Preserve] public string Status { get; set; }
 
-        [DataMember(Name = "username")] public string Username { get; set; }
+        [DataMember(Name = "username"), Preserve] public string Username { get; set; }
 
-        [DataMember(Name = "user_id")] public string UserId { get; set; }
+        [DataMember(Name = "user_id"), Preserve] public string UserId { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/src/Nakama/MatchJoinMessage.cs
+++ b/src/Nakama/MatchJoinMessage.cs
@@ -24,13 +24,13 @@ namespace Nakama
     /// </summary>
     internal class MatchJoinMessage
     {
-        [DataMember(Name="match_id")]
+        [DataMember(Name="match_id"), Preserve]
         public string MatchId { get; set; }
 
-        [DataMember(Name="token")]
+        [DataMember(Name="token"), Preserve]
         public string Token { get; set; }
-        
-        [DataMember(Name="metadata")]
+
+        [DataMember(Name="metadata"), Preserve]
         public IDictionary<string, string> Metadata { get; set; }
 
         public override string ToString()

--- a/src/Nakama/MatchLeaveMessage.cs
+++ b/src/Nakama/MatchLeaveMessage.cs
@@ -23,7 +23,7 @@ namespace Nakama
     /// </summary>
     internal class MatchLeaveMessage
     {
-        [DataMember(Name="match_id")]
+        [DataMember(Name="match_id"), Preserve]
         public string MatchId { get; set; }
 
         public override string ToString()

--- a/src/Nakama/MatchSendMessage.cs
+++ b/src/Nakama/MatchSendMessage.cs
@@ -24,16 +24,16 @@ namespace Nakama
     /// </summary>
     internal class MatchSendMessage
     {
-        [DataMember(Name="match_id")]
+        [DataMember(Name="match_id"), Preserve]
         public string MatchId { get; set; }
 
-        [DataMember(Name="op_code")]
+        [DataMember(Name="op_code"), Preserve]
         public string OpCode { get; set; }
 
-        [DataMember(Name="presences")]
+        [DataMember(Name="presences"), Preserve]
         public List<UserPresence> Presences { get; set; }
 
-        [DataMember(Name="data")]
+        [DataMember(Name="data"), Preserve]
         public string State { get; set; }
 
         public override string ToString()

--- a/src/Nakama/MatchmakerAddMessage.cs
+++ b/src/Nakama/MatchmakerAddMessage.cs
@@ -24,16 +24,16 @@ namespace Nakama
     /// </summary>
     internal class MatchmakerAddMessage
     {
-        [DataMember(Name = "max_count")] public int MaxCount { get; set; }
+        [DataMember(Name = "max_count"), Preserve] public int MaxCount { get; set; }
 
-        [DataMember(Name = "min_count")] public int MinCount { get; set; }
+        [DataMember(Name = "min_count"), Preserve] public int MinCount { get; set; }
 
-        [DataMember(Name = "numeric_properties")]
+        [DataMember(Name = "numeric_properties"), Preserve]
         public Dictionary<string, double> NumericProperties { get; set; }
 
-        [DataMember(Name = "query")] public string Query { get; set; }
+        [DataMember(Name = "query"), Preserve] public string Query { get; set; }
 
-        [DataMember(Name = "string_properties")]
+        [DataMember(Name = "string_properties"), Preserve]
         public Dictionary<string, string> StringProperties { get; set; }
 
         public override string ToString()

--- a/src/Nakama/MatchmakerRemoveMessage.cs
+++ b/src/Nakama/MatchmakerRemoveMessage.cs
@@ -23,7 +23,7 @@ namespace Nakama
     /// </summary>
     internal class MatchmakerRemoveMessage
     {
-        [DataMember(Name="ticket")]
+        [DataMember(Name="ticket"), Preserve]
         public string Ticket { get; set; }
 
         public override string ToString()

--- a/src/Nakama/PreserveAttribute.cs
+++ b/src/Nakama/PreserveAttribute.cs
@@ -1,1 +1,25 @@
+/*
+ * Copyright 2020 Heroic Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/// <summary>
+/// A custom attribute recognized by Unity3D. When added to a class member, it prevents
+/// the Unity linker from stripping the code it is associated with. This is used in addition
+/// to the link.xml file because the Unity Package Manager does not recognize link.xml files
+/// inside Unity packages.
+/// https://docs.unity3d.com/2018.3/Documentation/Manual/ManagedCodeStripping.html
+/// </summary>
 internal class PreserveAttribute : System.Attribute {}

--- a/src/Nakama/PreserveAttribute.cs
+++ b/src/Nakama/PreserveAttribute.cs
@@ -1,0 +1,1 @@
+internal class PreserveAttribute : System.Attribute {}

--- a/src/Nakama/StatusFollowMessage.cs
+++ b/src/Nakama/StatusFollowMessage.cs
@@ -24,9 +24,9 @@ namespace Nakama
     /// </summary>
     internal class StatusFollowMessage
     {
-        [DataMember(Name = "user_ids")] public List<string> UserIds { get; set; }
+        [DataMember(Name = "user_ids"), Preserve] public List<string> UserIds { get; set; }
 
-        [DataMember(Name = "usernames")] public List<string> Usernames { get; set; }
+        [DataMember(Name = "usernames"), Preserve] public List<string> Usernames { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/StatusUnfollowMessage.cs
+++ b/src/Nakama/StatusUnfollowMessage.cs
@@ -24,7 +24,7 @@ namespace Nakama
     /// </summary>
     internal class StatusUnfollowMessage
     {
-        [DataMember(Name="user_ids")]
+        [DataMember(Name="user_ids"), Preserve]
         public List<string> UserIds { get; set; }
 
         public override string ToString()

--- a/src/Nakama/StatusUpdateMessage.cs
+++ b/src/Nakama/StatusUpdateMessage.cs
@@ -23,7 +23,7 @@ namespace Nakama
     /// </summary>
     internal class StatusUpdateMessage
     {
-        [DataMember(Name="status")]
+        [DataMember(Name="status"), Preserve]
         public string Status { get; set; }
 
         public override string ToString()

--- a/src/Nakama/WebSocketErrorMessage.cs
+++ b/src/Nakama/WebSocketErrorMessage.cs
@@ -24,11 +24,11 @@ namespace Nakama
     /// </summary>
     internal class WebSocketErrorMessage
     {
-        [DataMember(Name = "code")] public int Code { get; set; }
+        [DataMember(Name = "code"), Preserve] public int Code { get; set; }
 
-        [DataMember(Name = "context")] public Dictionary<string, string> Context { get; set; }
+        [DataMember(Name = "context"), Preserve] public Dictionary<string, string> Context { get; set; }
 
-        [DataMember(Name = "message")] public string Message { get; set; }
+        [DataMember(Name = "message"), Preserve] public string Message { get; set; }
 
         public override string ToString()
         {

--- a/src/Nakama/WebSocketMessageEnvelope.cs
+++ b/src/Nakama/WebSocketMessageEnvelope.cs
@@ -23,97 +23,97 @@ namespace Nakama
     /// </summary>
     internal class WebSocketMessageEnvelope
     {
-        [DataMember(Name="cid")]
+        [DataMember(Name="cid"), Preserve]
         public string Cid { get; set; }
 
-        [DataMember(Name="channel")]
+        [DataMember(Name="channel"), Preserve]
         public Channel Channel { get; set; }
 
-        [DataMember(Name="channel_join")]
+        [DataMember(Name="channel_join"), Preserve]
         public ChannelJoinMessage ChannelJoin { get; set; }
 
-        [DataMember(Name="channel_leave")]
+        [DataMember(Name="channel_leave"), Preserve]
         public ChannelLeaveMessage ChannelLeave { get; set; }
 
-        [DataMember(Name="channel_message")]
+        [DataMember(Name="channel_message"), Preserve]
         public ApiChannelMessage ChannelMessage { get; set; }
-        
-        [DataMember(Name="channel_message_ack")]
+
+        [DataMember(Name="channel_message_ack"), Preserve]
         public ChannelMessageAck ChannelMessageAck { get; set; }
 
-        [DataMember(Name="channel_message_remove")]
+        [DataMember(Name="channel_message_remove"), Preserve]
         public ChannelRemoveMessage ChannelMessageRemove { get; set; }
 
-        [DataMember(Name="channel_message_send")]
+        [DataMember(Name="channel_message_send"), Preserve]
         public ChannelSendMessage ChannelMessageSend { get; set; }
 
-        [DataMember(Name="channel_message_update")]
+        [DataMember(Name="channel_message_update"), Preserve]
         public ChannelUpdateMessage ChannelMessageUpdate { get; set; }
 
-        [DataMember(Name="channel_presence_event")]
+        [DataMember(Name="channel_presence_event"), Preserve]
         public ChannelPresenceEvent ChannelPresenceEvent { get; set; }
 
-        [DataMember(Name="error")]
+        [DataMember(Name="error"), Preserve]
         public WebSocketErrorMessage Error { get; set; }
 
-        [DataMember(Name="matchmaker_add")]
+        [DataMember(Name="matchmaker_add"), Preserve]
         public MatchmakerAddMessage MatchmakerAdd { get; set; }
 
-        [DataMember(Name="matchmaker_matched")]
+        [DataMember(Name="matchmaker_matched"), Preserve]
         public MatchmakerMatched MatchmakerMatched { get; set; }
 
-        [DataMember(Name="matchmaker_remove")]
+        [DataMember(Name="matchmaker_remove"), Preserve]
         public MatchmakerRemoveMessage MatchmakerRemove { get; set; }
 
-        [DataMember(Name="matchmaker_ticket")]
+        [DataMember(Name="matchmaker_ticket"), Preserve]
         public MatchmakerTicket MatchmakerTicket { get; set; }
 
-        [DataMember(Name="match")]
+        [DataMember(Name="match"), Preserve]
         public Match Match { get; set; }
 
-        [DataMember(Name="match_create")]
+        [DataMember(Name="match_create"), Preserve]
         public MatchCreateMessage MatchCreate { get; set; }
 
-        [DataMember(Name="match_join")]
+        [DataMember(Name="match_join"), Preserve]
         public MatchJoinMessage MatchJoin { get; set; }
 
-        [DataMember(Name="match_leave")]
+        [DataMember(Name="match_leave"), Preserve]
         public MatchLeaveMessage MatchLeave { get; set; }
 
-        [DataMember(Name="match_presence_event")]
+        [DataMember(Name="match_presence_event"), Preserve]
         public MatchPresenceEvent MatchPresenceEvent { get; set; }
 
-        [DataMember(Name="match_data")]
+        [DataMember(Name="match_data"), Preserve]
         public MatchState MatchState { get; set; }
 
-        [DataMember(Name="match_data_send")]
+        [DataMember(Name="match_data_send"), Preserve]
         public MatchSendMessage MatchStateSend { get; set; }
 
-        [DataMember(Name="notifications")]
+        [DataMember(Name="notifications"), Preserve]
         public ApiNotificationList NotificationList { get; set; }
 
-        [DataMember(Name="rpc")]
+        [DataMember(Name="rpc"), Preserve]
         public ApiRpc Rpc { get; set; }
 
-        [DataMember(Name="status")]
+        [DataMember(Name="status"), Preserve]
         public Status Status { get; set; }
 
-        [DataMember(Name="status_follow")]
+        [DataMember(Name="status_follow"), Preserve]
         public StatusFollowMessage StatusFollow { get; set; }
 
-        [DataMember(Name="status_presence_event")]
+        [DataMember(Name="status_presence_event"), Preserve]
         public StatusPresenceEvent StatusPresenceEvent { get; set; }
 
-        [DataMember(Name="status_unfollow")]
+        [DataMember(Name="status_unfollow"), Preserve]
         public StatusUnfollowMessage StatusUnfollow { get; set; }
 
-        [DataMember(Name="status_update")]
+        [DataMember(Name="status_update"), Preserve]
         public StatusUpdateMessage StatusUpdate { get; set; }
 
-        [DataMember(Name="stream_presence_event")]
+        [DataMember(Name="stream_presence_event"), Preserve]
         public StreamPresenceEvent StreamPresenceEvent { get; set; }
 
-        [DataMember(Name="stream_data")]
+        [DataMember(Name="stream_data"), Preserve]
         public StreamState StreamState { get; set; }
 
         public override string ToString()


### PR DESCRIPTION
The UPM doesn't support `link.xml`, so we manually need to add a custom `Preserve` attribute alongside code that would ordinarily by stripped by the Unity linker.

I'm keeping the `link.xml` for any users who want to import the sdk the "old-fashioned" way. 