### PR TITLE
return decoded error message rather than error dictionary when rpc fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added Apple single sign-on support.
+- Added Steam single sign-on support.
+- Fixed serialization of HTTP API error messages.
 
 ## [2.5.0] - 2020-08-12
 ### Added
@@ -30,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Prevent InvalidOperationException caused when socket connect task is already completed.
 
 ## [2.3.1] - 2019-09-21
-### Changed 
+### Changed
 - Use workaround for IPv6 bug in TcpClient with Mono runtime used with Unity engine.
 
 ### Fixed

--- a/src/Nakama/HttpRequestAdapter.cs
+++ b/src/Nakama/HttpRequestAdapter.cs
@@ -80,7 +80,7 @@ namespace Nakama
             }
 
             var decoded = contents.FromJson<Dictionary<string, object>>();
-            throw new ApiResponseException((int) response.StatusCode, decoded["error"].ToString(),
+            throw new ApiResponseException((int) response.StatusCode, decoded["message"].ToString(),
                 (int) decoded["code"]);
         }
 

--- a/src/Nakama/HttpRequestAdapter.cs
+++ b/src/Nakama/HttpRequestAdapter.cs
@@ -84,7 +84,7 @@ namespace Nakama
             var exception = new ApiResponseException((int) response.StatusCode, decoded["message"].ToString(),
                 (int) decoded["code"]);
 
-            CopyErrorDictionary(decoded, exception);
+            this.CopyErrorDictionary(decoded, exception);
             throw exception;
         }
 
@@ -108,20 +108,6 @@ namespace Nakama
             var client =
                 new HttpClient(compression ? (HttpMessageHandler) new GZipHttpClientHandler(handler) : handler);
             return new HttpRequestAdapter(client);
-        }
-
-        /// <summary>
-        /// Copies in-place the keys and values of additional error information from the API Response into
-        /// the provided APIResponseException.
-        /// </summary>
-        private static void CopyErrorDictionary(Dictionary<string, object> decodedResponse, ApiResponseException e)
-        {
-            var errDict = decodedResponse["error"] as Dictionary<string, object>;
-
-            foreach (KeyValuePair<string, object> keyVal in errDict)
-            {
-                e.Data[keyVal.Key] = keyVal.Value;
-            }
         }
     }
 }

--- a/src/Nakama/HttpRequestAdapter.cs
+++ b/src/Nakama/HttpRequestAdapter.cs
@@ -80,8 +80,12 @@ namespace Nakama
             }
 
             var decoded = contents.FromJson<Dictionary<string, object>>();
-            throw new ApiResponseException((int) response.StatusCode, decoded["message"].ToString(),
+
+            var exception = new ApiResponseException((int) response.StatusCode, decoded["message"].ToString(),
                 (int) decoded["code"]);
+
+            CopyErrorDictionary(decoded, exception);
+            throw exception;
         }
 
         /// <summary>
@@ -104,6 +108,20 @@ namespace Nakama
             var client =
                 new HttpClient(compression ? (HttpMessageHandler) new GZipHttpClientHandler(handler) : handler);
             return new HttpRequestAdapter(client);
+        }
+
+        /// <summary>
+        /// Copies in-place the keys and values of additional error information from the API Response into
+        /// the provided APIResponseException.
+        /// </summary>
+        private static void CopyErrorDictionary(Dictionary<string, object> decodedResponse, ApiResponseException e)
+        {
+            var errDict = decodedResponse["error"] as Dictionary<string, object>;
+
+            foreach (KeyValuePair<string, object> keyVal in errDict)
+            {
+                e.Data[keyVal.Key] = keyVal.Value;
+            }
         }
     }
 }

--- a/src/Nakama/IHttpAdapter.cs
+++ b/src/Nakama/IHttpAdapter.cs
@@ -1,5 +1,5 @@
 ﻿/**
- * Copyright 2019 The Nakama Authors
+ * Copyright 2020 The Nakama Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Nakama/IHttpAdapterExt.cs
+++ b/src/Nakama/IHttpAdapterExt.cs
@@ -1,4 +1,20 @@
 
+/**
+ * Copyright 2020 The Nakama Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 
 namespace Nakama

--- a/src/Nakama/IHttpAdapterExt.cs
+++ b/src/Nakama/IHttpAdapterExt.cs
@@ -1,0 +1,28 @@
+
+using System.Collections.Generic;
+
+namespace Nakama
+{
+    /// <summary>
+    /// Extension methods for the <see cref="IHttpAdapter"> interface.
+    /// </summary>
+    public static class IHttpAdapterExt
+    {
+        /// <summary>
+        /// Performs an in-place copy of keys and values from Nakama's error response dictionary into
+        /// the data dictionary of an <see cref="ApiResponseException"/>.
+        /// <param name="adapter">The adapter receiving the error response.</param>
+        /// <param name="decodedResponse"> The decoded error response from the server.</param>
+        /// <param name="e"> The exception whose data dictionary is being written to.</param>
+        /// </summary>
+        public static void CopyErrorDictionary(this IHttpAdapter adapter, Dictionary<string, object> decodedResponse, ApiResponseException e)
+        {
+            var errDict = decodedResponse["error"] as Dictionary<string, object>;
+
+            foreach (KeyValuePair<string, object> keyVal in errDict)
+            {
+                e.Data[keyVal.Key] = keyVal.Value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When an HTTP request in this SDK fails, it returns the following structure:

```
{
   "code":13,
   "error":{
      "Type":2,
      "Object":"/Users/lugehorsam/go/src/github.com/heroiclabs/nakama/data/modules/clientrpc.lua:37: {\"test_error_key\":\"test_error_value\"}",
      "StackTrace":"stack traceback:\n\t[G]: in function 'error'\n\t/Users/lugehorsam/go/src/github.com/heroiclabs/nakama/data/modules/clientrpc.lua:37: in main chunk\n\t[G]: ?",
      "Cause":null
   },
   "message":"/Users/lugehorsam/go/src/github.com/heroiclabs/nakama/data/modules/clientrpc.lua:37: {\"test_error_key\":\"test_error_value\"}\nstack traceback:\n\t[G]: in function 'error'\n\t/Users/lugehorsam/go/src/github.com/heroiclabs/nakama/data/modules/clientrpc.lua:37: in main chunk\n\t[G]: ?"
}
```

We surfaced this error by taking the `error` field of this response and placing it in our custom `APIResponseException` message. This made the exception opaque when trying to stringify its message as a dictionary object.

Instead my proposal is to map the response `message` to the `message` field in `ApiException`.

If this approach makes sense, some remaining items:

- [ ] Updating the UnityWebRequestAdapter
- [x] Possibly placing the `error` dictionary into the exception's `data` field. 
- [x] Determine whether this would negatively affect any existing users' exception tracking tools
