### PR TITLE
Proof of Concept: Containerized Integration Tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as nakama-dotnet
 ARG username=nakama-test-runner
 
-RUN useradd -ms /bin/bash nakama-test-runner
+RUN useradd -ms /bin/bash $username
 
 USER $username
 COPY --chown=$username . /home/$username/dotnet-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as nakama-dotnet
-ARG username=nakama-test-runner
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+ARG username=nakama-dotnet-user
 
 RUN useradd -ms /bin/bash $username
 
 USER $username
 COPY --chown=$username . /home/$username/dotnet-sdk
 WORKDIR /home/$username/dotnet-sdk
-ENTRYPOINT dotnet build && dotnet test
+RUN dotnet build
+ENTRYPOINT dotnet test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as nakama-dotnet
+ARG username=nakama-test-runner
+
+RUN useradd -ms /bin/bash nakama-test-runner
+
+USER $username
+COPY --chown=$username . /home/$username/dotnet-sdk
+WORKDIR /home/$username/dotnet-sdk
+ENTRYPOINT dotnet build && dotnet test

--- a/README.md
+++ b/README.md
@@ -121,17 +121,28 @@ dotnet pack -p:AssemblyVersion=2.0.0.0 -p:PackageVersion=2.0.0 -c Release src/Na
 
 ### Run Tests
 
-To run tests you will need to run the server and database. Most tests are written as integration tests which execute against the server. A quick approach we use with our test workflow is to use the Docker compose file described in the [documentation](https://heroiclabs.com/docs/install-docker-quickstart).
+With Docker Compose:
+
+We use Docker to automate our tests using the following steps:
+
+(1) Pull a test image of the Nakama server with test runtime code loaded.
+(2) Pull a CockroachDB image.
+(3) Build a test image of the SDK and run integration tests between these three images.
+
+To run these steps, build the SDK image and run Docker Compose:
+`docker image build --tag=heroiclabs/nakama-dotnet:latest . && docker-compose up`
+
+With Host Machine:
+
+Some contributors may want to either contribute to the (Nakama runtime)[https://heroiclabs.com/docs/runtime-code-basics/] test suite or run tests directly on their host machine. To do so, you will need to install the Nakama server test image locally and modify its RPC suite. See
+https://github.com/heroiclabs/nakama-clientsdk-test for details on how to do this.
+
+Then run `dotnet test` inside this repository to test the SDK on your host machine.
+
+If you want to isolate a specific test, pass the name of the test method (with the option of being fully qualified) to `dotnet test --filter`:
 
 ```shell
-docker-compose -f ./docker-compose-postgres.yml up
-dotnet test tests/Nakama.Tests/Nakama.Tests.csproj
-```
-
-To run a specific test, pass the fully qualified name of the method to `dotnet test --filter`:
-
-```shell
-dotnet test --filter "Nakama.Tests.Api.GroupTest.ShouldPromoteAndDemoteUsers"
+dotnet test --filter "ShouldPromoteAndDemoteUsers"
 ```
 
 ### License

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  cockroachdb:
+    image: cockroachdb/cockroach:v19.2.2
+    command: start --insecure --store=attrs=ssd,path=/var/lib/cockroach/
+    restart: "no"
+  nakama:
+    image: heroiclabs/nakama-clientsdk-test:latest
+    entrypoint:
+      - "/bin/sh"
+      - "-ecx"
+      - >
+          /nakama/nakama migrate up --database.address root@cockroachdb:26257 &&
+          exec /nakama/nakama --name nakama1 --database.address root@cockroachdb:26257 --logger.level DEBUG --session.token_expiry_sec 7200 --metrics.prometheus_port 9100
+    restart: "no"
+    links:
+      - "cockroachdb:db"
+    depends_on:
+      - cockroachdb
+  nakama-dotnet:
+    image: heroiclabs/nakama-dotnet:latest
+    depends_on:
+      - nakama
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,12 @@ services:
     image: cockroachdb/cockroach:v19.2.2
     command: start --insecure --store=attrs=ssd,path=/var/lib/cockroach/
     restart: "no"
+    expose:
+      - "8080"
+      - "26257"
+    ports:
+      - "26257:26257"
+      - "8080:8080"
   nakama:
     image: heroiclabs/nakama-clientsdk-test:latest
     entrypoint:
@@ -13,12 +19,24 @@ services:
           /nakama/nakama migrate up --database.address root@cockroachdb:26257 &&
           exec /nakama/nakama --name nakama1 --database.address root@cockroachdb:26257 --logger.level DEBUG --session.token_expiry_sec 7200 --metrics.prometheus_port 9100
     restart: "no"
-    links:
-      - "cockroachdb:db"
     depends_on:
       - cockroachdb
+    expose:
+      - "7349"
+      - "7350"
+    ports:
+      - "7349:7349"
+      - "7350:7350"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7350/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   nakama-dotnet:
     image: heroiclabs/nakama-dotnet:latest
     depends_on:
       - nakama
+    network_mode: "host"
+
 


### PR DESCRIPTION
This is a POC on how an SDK can use an extended Nakama image loaded with rpc functions to run integration tests against.

See https://github.com/heroiclabs/nakama-clientsdk-test for how this image is built and the associated rpc functions. The image it builds is currently on Docker Hub: https://hub.docker.com/repository/docker/heroiclabs/nakama-clientsdk-test

For test social provider keys, I propose an optional bind mount from the host machine and corresponding optional tests that are triggered in each SDK if such keys exist.

Remaining Steps:

(1) Make client-sdk test image repository public *(before merging!)*
(2) Versioning for test image on Docker Hub and make it public also *(before merging!)*
(3) Integrate with Github Actions
(4) Finalize approach for test keys