### PR TITLE
Restore dotnet client socket tests

### DIFF
--- a/tests/Nakama.Tests/AwaitedSocketTaskTest.cs
+++ b/tests/Nakama.Tests/AwaitedSocketTaskTest.cs
@@ -28,7 +28,7 @@ namespace Nakama.Tests
         public AwaitedSocketTaskTest()
         {
             _client = ClientUtil.FromSettingsFile();
-            _socket = Socket.From(_client);
+            _socket = Nakama.Socket.From(_client);
         }
 
         public void Dispose()

--- a/tests/Nakama.Tests/GroupTest.cs
+++ b/tests/Nakama.Tests/GroupTest.cs
@@ -30,7 +30,7 @@ namespace Nakama.Tests.Api
         public GroupTest()
         {
             _client = ClientUtil.FromSettingsFile();
-            _socket = Socket.From(_client);
+            _socket = Nakama.Socket.From(_client);
         }
 
         [Fact]

--- a/tests/Nakama.Tests/LinkUnlinkTest.cs
+++ b/tests/Nakama.Tests/LinkUnlinkTest.cs
@@ -17,7 +17,6 @@
 namespace Nakama.Tests.Api
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;

--- a/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The Nakama Authors
+ * Copyright 2020 The Nakama Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
@@ -27,8 +27,6 @@ namespace Nakama.Tests.Socket
         private IClient _client;
         private ISocket _socket;
 
-        // ReSharper disable RedundantArgumentDefaultValue
-
         public WebSocketChannelTest()
         {
             _client = new Client("http", "defaultkey", 7350, "127.0.0.1");

--- a/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
@@ -29,7 +29,7 @@ namespace Nakama.Tests.Socket
 
         public WebSocketChannelTest()
         {
-            _client = new Client("http", "defaultkey", 7350, "127.0.0.1");
+            _client = ClientUtil.FromSettingsFile();
             _socket = Nakama.Socket.From(_client);
         }
 

--- a/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
@@ -19,30 +19,23 @@ namespace Nakama.Tests.Socket
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NUnit.Framework;
+    using Xunit;
     using TinyJson;
 
-    [TestFixture]
-    public class WebSocketChannelTest
+    public class WebSocketChannelTest : IAsyncLifetime
     {
         private IClient _client;
         private ISocket _socket;
 
         // ReSharper disable RedundantArgumentDefaultValue
-        [SetUp]
-        public void SetUp()
+
+        public WebSocketChannelTest()
         {
-            _client = new Client("defaultkey", "127.0.0.1", 7350, false);
-            _socket = _client.CreateWebSocket();
+            _client = new Client("http", "defaultkey", 7350, "127.0.0.1");
+            _socket = Nakama.Socket.From(_client);
         }
 
-        [TearDown]
-        public async Task TearDown()
-        {
-            await _socket.DisconnectAsync(false);
-        }
-
-        [Test]
+        [Fact]
         public async Task ShouldCreateRoomChannel()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
@@ -51,17 +44,17 @@ namespace Nakama.Tests.Socket
 
             Assert.NotNull(channel);
             Assert.NotNull(channel.Id);
-            Assert.AreEqual(channel.Self.UserId, session.UserId);
-            Assert.AreEqual(channel.Self.Username, session.Username);
+            Assert.Equal(channel.Self.UserId, session.UserId);
+            Assert.Equal(channel.Self.Username, session.Username);
         }
 
-        [Test]
+        [Fact]
         public async Task ShouldSendMessageRoomChannel()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
 
             var completer = new TaskCompletionSource<IApiChannelMessage>();
-            _socket.OnChannelMessage += (sender, chatMessage) => completer.SetResult(chatMessage);
+            _socket.ReceivedChannelMessage += (chatMessage) => completer.SetResult(chatMessage);
             await _socket.ConnectAsync(session);
             var channel = await _socket.JoinChatAsync("myroom", ChannelType.Room);
 
@@ -72,12 +65,12 @@ namespace Nakama.Tests.Socket
 
             Assert.NotNull(sendAck);
             Assert.NotNull(message);
-            Assert.AreEqual(sendAck.ChannelId, message.ChannelId);
-            Assert.AreEqual(sendAck.MessageId, message.MessageId);
-            Assert.AreEqual(sendAck.Username, message.Username);
+            Assert.Equal(sendAck.ChannelId, message.ChannelId);
+            Assert.Equal(sendAck.MessageId, message.MessageId);
+            Assert.Equal(sendAck.Username, message.Username);
         }
 
-        [Test]
+        [Fact]
         public async Task ShouldSendMessageDirectChannel()
         {
             var session1 = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
@@ -87,10 +80,10 @@ namespace Nakama.Tests.Socket
             await _client.AddFriendsAsync(session2, new[] {session1.UserId});
 
             var completer = new TaskCompletionSource<IApiChannelMessage>();
-            _socket.OnChannelMessage += (sender, chatMessage) => completer.SetResult(chatMessage);
+            _socket.ReceivedChannelMessage += (chatMessage) => completer.SetResult(chatMessage);
             await _socket.ConnectAsync(session1);
 
-            var socket2 = _client.CreateWebSocket();
+            var socket2 = Nakama.Socket.From(_client);
             await socket2.ConnectAsync(session2);
             var channel = await _socket.JoinChatAsync(session2.UserId, ChannelType.DirectMessage, false, false);
 
@@ -101,9 +94,19 @@ namespace Nakama.Tests.Socket
 
             Assert.NotNull(sendAck);
             Assert.NotNull(message);
-            Assert.AreEqual(sendAck.ChannelId, message.ChannelId);
-            Assert.AreEqual(sendAck.MessageId, message.MessageId);
-            Assert.AreEqual(sendAck.Username, message.Username);
+            Assert.Equal(sendAck.ChannelId, message.ChannelId);
+            Assert.Equal(sendAck.MessageId, message.MessageId);
+            Assert.Equal(sendAck.Username, message.Username);
+        }
+
+        Task IAsyncLifetime.InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        Task IAsyncLifetime.DisposeAsync()
+        {
+            return _socket.CloseAsync();
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketMatchTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketMatchTest.cs
@@ -67,8 +67,9 @@ namespace Nakama.Tests.Socket
             Assert.NotNull(match2);
             Assert.Equal(match1.Id, match2.Id);
             Assert.Equal(match1.Label, match2.Label);
-            Assert.True(match1.Presences.Count() ==  1);
-            Assert.True(match2.Presences.Count() == 2);
+
+            Assert.True(match1.Presences.Count() == 0 && match1.Self.UserId == session1.UserId);
+            Assert.True(match2.Presences.Count() == 1);
 
             await socket2.CloseAsync();
         }

--- a/tests/Nakama.Tests/Socket/WebSocketMatchTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketMatchTest.cs
@@ -18,8 +18,9 @@ namespace Nakama.Tests.Socket
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading.Tasks;
     using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
     using Xunit;
     using TinyJson;
 
@@ -106,7 +107,7 @@ namespace Nakama.Tests.Socket
 
             var result = await completer.Task;
             Assert.NotNull(result);
-            Assert.Equal(newState, result.ToJson());
+            Assert.Equal(newState, Encoding.UTF8.GetString(result.State));
         }
 
         Task IAsyncLifetime.InitializeAsync()

--- a/tests/Nakama.Tests/Socket/WebSocketMatchTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketMatchTest.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The Nakama Authors
+ * Copyright 2020 The Nakama Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,31 +19,24 @@ namespace Nakama.Tests.Socket
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NUnit.Framework;
+    using System.Linq;
+    using Xunit;
     using TinyJson;
 
-    [TestFixture]
-    [Ignore("Flakey. Needs improvement.")]
-    public class WebSocketMatchTest
+    // "Flakey. Needs improvement."
+    public class WebSocketMatchTest : IAsyncLifetime
     {
         private IClient _client;
         private ISocket _socket;
 
         // ReSharper disable RedundantArgumentDefaultValue
-        [SetUp]
-        public void SetUp()
+        public WebSocketMatchTest()
         {
-            _client = new Client("defaultkey", "127.0.0.1", 7350, false);
-            _socket = _client.CreateWebSocket();
+            _client = ClientUtil.FromSettingsFile();
+            _socket = Nakama.Socket.From(_client);
         }
 
-        [TearDown]
-        public async Task TearDown()
-        {
-            await _socket.DisconnectAsync(false);
-        }
-
-        [Test]
+        [Fact]
         public async Task ShouldCreateMatch()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
@@ -52,19 +45,18 @@ namespace Nakama.Tests.Socket
 
             Assert.NotNull(match);
             Assert.NotNull(match.Id);
-            Assert.IsNotEmpty(match.Id);
+            Assert.NotEmpty(match.Id);
             Assert.False(match.Authoritative);
-            Assert.NotZero(match.Size);
-            Assert.Positive(match.Size);
+            Assert.True(match.Size > 0);
         }
 
-        [Test]
+        [Fact]
         public async Task ShouldCreateMatchAndSecondUserJoin()
         {
             var session1 = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
             var session2 = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
             await _socket.ConnectAsync(session1);
-            var socket2 = _client.CreateWebSocket();
+            var socket2 = Nakama.Socket.From(_client);
             await socket2.ConnectAsync(session2);
 
             var match1 = await _socket.CreateMatchAsync();
@@ -72,15 +64,15 @@ namespace Nakama.Tests.Socket
 
             Assert.NotNull(match1);
             Assert.NotNull(match2);
-            Assert.AreEqual(match1.Id, match2.Id);
-            Assert.AreEqual(match1.Label, match2.Label);
-            Assert.That(match1.Presences, Has.Count.EqualTo(1));
-            Assert.That(match2.Presences, Has.Count.EqualTo(2));
+            Assert.Equal(match1.Id, match2.Id);
+            Assert.Equal(match1.Label, match2.Label);
+            Assert.True(match1.Presences.Count() ==  1);
+            Assert.True(match2.Presences.Count() == 2);
 
-            await socket2.DisconnectAsync(false);
+            await socket2.CloseAsync();
         }
 
-        [Test]
+        [Fact]
         public async Task ShouldCreateMatchAndLeave()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
@@ -89,32 +81,42 @@ namespace Nakama.Tests.Socket
 
             Assert.NotNull(match);
             Assert.NotNull(match.Id);
-            Assert.DoesNotThrowAsync(() => _socket.LeaveMatchAsync(match.Id));
+            await _socket.LeaveMatchAsync(match.Id);
         }
 
-        [Test]
+        [Fact]
         public async Task ShouldCreateMatchAndSendState()
         {
             var session1 = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
             var session2 = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
 
-            _socket = _client.CreateWebSocket();
+            _socket = Nakama.Socket.From(_client);
             await _socket.ConnectAsync(session1);
 
-            var socket2 = _client.CreateWebSocket();
+            var socket2 = Nakama.Socket.From(_client);
             var completer = new TaskCompletionSource<IMatchState>();
-            socket2.OnMatchState += (_, state) => completer.SetResult(state);
+            socket2.ReceivedMatchState += (state) => completer.SetResult(state);
             await socket2.ConnectAsync(session2);
 
             var match = await _socket.CreateMatchAsync();
             await socket2.JoinMatchAsync(match.Id);
 
             var newState = new Dictionary<string, string> {{"hello", "world"}}.ToJson();
-            _socket.SendMatchState(match.Id, 0, newState);
+            await _socket.SendMatchStateAsync(match.Id, 0, newState);
 
             var result = await completer.Task;
             Assert.NotNull(result);
-            Assert.AreEqual(newState, result.State);
+            Assert.Equal(newState, result.ToJson());
+        }
+
+        Task IAsyncLifetime.InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        Task IAsyncLifetime.DisposeAsync()
+        {
+            return _socket.CloseAsync();
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketMatchmakerTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketMatchmakerTest.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The Nakama Authors
+ * Copyright 2020 The Nakama Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,29 +18,21 @@ namespace Nakama.Tests.Socket
 {
     using System;
     using System.Threading.Tasks;
-    using NUnit.Framework;
+    using Xunit;
 
-    [TestFixture]
-    public class WebSocketMatchmakerTest
+    public class WebSocketMatchmakerTest : IAsyncLifetime
     {
         private IClient _client;
         private ISocket _socket;
 
-        // ReSharper disable RedundantArgumentDefaultValue
-        [SetUp]
-        public void SetUp()
+
+        public WebSocketMatchmakerTest()
         {
-            _client = new Client("defaultkey", "127.0.0.1", 7350, false);
-            _socket = _client.CreateWebSocket();
+            ClientUtil.FromSettingsFile();
+            _socket = Nakama.Socket.From(_client);
         }
 
-        [TearDown]
-        public async Task TearDown()
-        {
-            await _socket.DisconnectAsync(false);
-        }
-
-        [Test]
+        [Fact]
         public async Task ShouldJoinMatchmaker()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
@@ -48,11 +40,11 @@ namespace Nakama.Tests.Socket
             var matchmakerTicket = await _socket.AddMatchmakerAsync("*");
 
             Assert.NotNull(matchmakerTicket);
-            Assert.IsNotEmpty(matchmakerTicket.Ticket);
+            Assert.Empty(matchmakerTicket.Ticket);
         }
 
-        [Test]
-        [Ignore("Flakey. Needs improvement.")]
+        // "Flakey. Needs improvement."
+        [Fact]
         public async Task ShouldJoinAndLeaveMatchmaker()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
@@ -60,8 +52,18 @@ namespace Nakama.Tests.Socket
             var matchmakerTicket = await _socket.AddMatchmakerAsync("*");
 
             Assert.NotNull(matchmakerTicket);
-            Assert.IsNotEmpty(matchmakerTicket.Ticket);
-            Assert.DoesNotThrowAsync(() => _socket.RemoveMatchmakerAsync(matchmakerTicket));
+            Assert.Empty(matchmakerTicket.Ticket);
+            await _socket.RemoveMatchmakerAsync(matchmakerTicket);
+        }
+
+        Task IAsyncLifetime.InitializeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        Task IAsyncLifetime.DisposeAsync()
+        {
+            return _socket.CloseAsync();
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketMatchmakerTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketMatchmakerTest.cs
@@ -25,10 +25,9 @@ namespace Nakama.Tests.Socket
         private IClient _client;
         private ISocket _socket;
 
-
         public WebSocketMatchmakerTest()
         {
-            ClientUtil.FromSettingsFile();
+            _client = ClientUtil.FromSettingsFile();
             _socket = Nakama.Socket.From(_client);
         }
 
@@ -40,7 +39,7 @@ namespace Nakama.Tests.Socket
             var matchmakerTicket = await _socket.AddMatchmakerAsync("*");
 
             Assert.NotNull(matchmakerTicket);
-            Assert.Empty(matchmakerTicket.Ticket);
+            Assert.NotEmpty(matchmakerTicket.Ticket);
         }
 
         // "Flakey. Needs improvement."
@@ -52,13 +51,13 @@ namespace Nakama.Tests.Socket
             var matchmakerTicket = await _socket.AddMatchmakerAsync("*");
 
             Assert.NotNull(matchmakerTicket);
-            Assert.Empty(matchmakerTicket.Ticket);
+            Assert.NotEmpty(matchmakerTicket.Ticket);
             await _socket.RemoveMatchmakerAsync(matchmakerTicket);
         }
 
         Task IAsyncLifetime.InitializeAsync()
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
 
         Task IAsyncLifetime.DisposeAsync()

--- a/tests/Nakama.Tests/Socket/WebSocketTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketTest.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The Nakama Authors
+ * Copyright 2020 The Nakama Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Nakama.Tests/Socket/WebSocketTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketTest.cs
@@ -71,24 +71,12 @@ namespace Nakama.Tests.Socket
         public async Task ShouldCreateSocketAndDisconnectSilent()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
-            var completer = new TaskCompletionSource<bool>();
-            _socket.Closed += () => completer.SetResult(true);
 
             await _socket.ConnectAsync(session);
-            completer.SetResult(false);
+            Assert.True(_socket.IsConnected);
+
             await _socket.CloseAsync();
-
-            Assert.False(await completer.Task);
-        }
-
-        [Fact]
-        public async Task ShouldCreateSocketAndDisconnectNoConnect()
-        {
-            var completer = new TaskCompletionSource<bool>();
-            _socket.Closed += () => completer.SetResult(true);
-            await  _socket.CloseAsync();
-
-            Assert.True(await completer.Task);
+            Assert.False(_socket.IsConnected);
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketTest.cs
@@ -17,6 +17,7 @@
 namespace Nakama.Tests.Socket
 {
     using System;
+    using System.Net.Sockets;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -77,6 +78,15 @@ namespace Nakama.Tests.Socket
 
             await _socket.CloseAsync();
             Assert.False(_socket.IsConnected);
+        }
+
+        [Fact]
+        public async Task MultipleConnectAttemptsThrowException()
+        {
+            var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
+            await _socket.ConnectAsync(session);
+            Assert.True(_socket.IsConnected);
+            await Assert.ThrowsAsync<SocketException>(() => _socket.ConnectAsync(session));
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketUserStatusTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketUserStatusTest.cs
@@ -22,7 +22,7 @@ using Xunit;
 namespace Nakama.Tests.Socket
 {
     // NOTE Test name patterns are: MethodName_StateUnderTest_ExpectedBehavior
-    public class WebSocketUserStatusTest : IDisposable
+    public class WebSocketUserStatusTest : IAsyncLifetime
     {
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(2);
 
@@ -33,12 +33,6 @@ namespace Nakama.Tests.Socket
         {
             _client = ClientUtil.FromSettingsFile();
             _socket = Nakama.Socket.From(_client);
-        }
-
-        public void Dispose()
-        {
-            _socket.Dispose();
-            _client = null;
         }
 
         [Fact]
@@ -226,6 +220,16 @@ namespace Nakama.Tests.Socket
             var result = await completer.Task;
             Assert.NotNull(result);
             Assert.Contains(result.Joins, joined => joined.UserId.Equals(session.UserId));
+        }
+
+        Task IAsyncLifetime.InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        Task IAsyncLifetime.DisposeAsync()
+        {
+            return _socket.CloseAsync();
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketUserStatusTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketUserStatusTest.cs
@@ -44,7 +44,7 @@ namespace Nakama.Tests.Socket
 
             var completer = new TaskCompletionSource<IStatusPresenceEvent>();
             var canceller = new CancellationTokenSource();
-            canceller.Token.Register(() => completer.SetCanceled());
+            canceller.Token.Register(() => completer.TrySetCanceled());
             canceller.CancelAfter(Timeout);
             _socket.ReceivedStatusPresence += statuses => completer.SetResult(statuses);
             _socket.ReceivedError += e => completer.TrySetException(e);
@@ -69,7 +69,7 @@ namespace Nakama.Tests.Socket
 
             var completer = new TaskCompletionSource<IStatusPresenceEvent>();
             var canceller = new CancellationTokenSource();
-            canceller.Token.Register(() => completer.SetCanceled());
+            canceller.Token.Register(() => completer.TrySetCanceled());
             canceller.CancelAfter(Timeout);
             _socket.ReceivedStatusPresence += statuses => completer.SetResult(statuses);
             _socket.ReceivedError += e => completer.TrySetException(e);
@@ -106,7 +106,7 @@ namespace Nakama.Tests.Socket
 
             var completer1 = new TaskCompletionSource<IStatusPresenceEvent>();
             var canceller = new CancellationTokenSource();
-            canceller.Token.Register(() => completer1.SetCanceled());
+            canceller.Token.Register(() => completer1.TrySetCanceled());
             canceller.CancelAfter(Timeout);
             _socket.ReceivedStatusPresence += statuses => completer1.TrySetResult(statuses);
             _socket.ReceivedError += e => completer1.TrySetException(e);
@@ -210,7 +210,7 @@ namespace Nakama.Tests.Socket
 
             var completer = new TaskCompletionSource<IStatusPresenceEvent>();
             var canceller = new CancellationTokenSource();
-            canceller.Token.Register(() => completer.SetCanceled());
+            canceller.Token.Register(() => completer.TrySetCanceled());
             canceller.CancelAfter(Timeout);
             _socket.ReceivedStatusPresence += statuses => completer.SetResult(statuses);
             _socket.ReceivedError += e => completer.TrySetException(e);

--- a/tests/Nakama.Tests/Socket/WebSocketUserStatusTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketUserStatusTest.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The Nakama Authors
+ * Copyright 2020 The Nakama Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,20 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Nakama.Tests
+namespace Nakama.Tests.Socket
 {
     // NOTE Test name patterns are: MethodName_StateUnderTest_ExpectedBehavior
-    public class SocketUserStatusTest : IDisposable
+    public class WebSocketUserStatusTest : IDisposable
     {
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(2);
 
         private IClient _client;
         private readonly ISocket _socket;
 
-        public SocketUserStatusTest()
+        public WebSocketUserStatusTest()
         {
             _client = ClientUtil.FromSettingsFile();
-            _socket = Socket.From(_client);
+            _socket = Nakama.Socket.From(_client);
         }
 
         public void Dispose()
@@ -57,7 +57,7 @@ namespace Nakama.Tests
             await _socket.ConnectAsync(session1);
             await _socket.FollowUsersAsync(new[] {session2.UserId});
 
-            var socket = Socket.From(_client);
+            var socket = Nakama.Socket.From(_client);
             await socket.ConnectAsync(session2);
             await socket.UpdateStatusAsync("new status change");
 
@@ -82,7 +82,7 @@ namespace Nakama.Tests
             await _socket.ConnectAsync(session1);
             await _socket.FollowUsersAsync(new string[] { }, new[] {session2.Username});
 
-            var socket = Socket.From(_client);
+            var socket = Nakama.Socket.From(_client);
             await socket.ConnectAsync(session2);
             await socket.UpdateStatusAsync("new status change");
 
@@ -120,7 +120,7 @@ namespace Nakama.Tests
             await _socket.FollowUsersAsync(new[] {session2.UserId});
 
             // Second user comes online and sets status.
-            var socket = Socket.From(_client);
+            var socket = Nakama.Socket.From(_client);
             await socket.ConnectAsync(session2);
             await socket.UpdateStatusAsync("new status change");
 
@@ -149,10 +149,10 @@ namespace Nakama.Tests
 
             var id2 = Guid.NewGuid().ToString();
             var session2 = await _client.AuthenticateCustomAsync(id2);
-            var socket1 = Socket.From(_client);
+            var socket1 = Nakama.Socket.From(_client);
             //socket1.ReceivedError
             await socket1.ConnectAsync(session2);
-            var socket2 = Socket.From(_client);
+            var socket2 = Nakama.Socket.From(_client);
             //socket2.ReceivedError
             await socket2.ConnectAsync(session2);
 
@@ -174,17 +174,17 @@ namespace Nakama.Tests
         public async void FollowUsers_TwoUsers_ThirdUserFollowsBoth()
         {
             var id1 = Guid.NewGuid().ToString();
-            var socket1 = Socket.From(_client);
+            var socket1 = Nakama.Socket.From(_client);
             //socket1.ReceivedError
             var session1 = await _client.AuthenticateCustomAsync(id1);
 
             var id2 = Guid.NewGuid().ToString();
-            var socket2 = Socket.From(_client);
+            var socket2 = Nakama.Socket.From(_client);
             //socket2.ReceivedError
             var session2 = await _client.AuthenticateCustomAsync(id2);
 
             var id3 = Guid.NewGuid().ToString();
-            var socket3 = Socket.From(_client);
+            var socket3 = Nakama.Socket.From(_client);
             //socket3.ReceivedError
             var session3 = await _client.AuthenticateCustomAsync(id3);
 


### PR DESCRIPTION
Converts unused socket tests to xunit and places them in the active tests directory.