### PR TITLE
Use TrySetResult rather than SetResult on socket connect

### DIFF
--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -178,7 +178,7 @@ namespace Nakama
             int connectTimeoutSec = DefaultConnectTimeout)
         {
             var tcs = new TaskCompletionSource<bool>();
-            Action callback = () => tcs.SetResult(true);
+            Action callback = () => tcs.TrySetResult(true);
             Action<Exception> errback = e => tcs.TrySetException(e);
             _adapter.Connected += callback;
             _adapter.ReceivedError += errback;


### PR DESCRIPTION
Closes #41 

I wanted to discuss this approach a little further; it is essentially "silencing" a benign error rather than doing a root cause fix. However, because we cannot reproduce the circumstances described in the linked issue, it may the best we can do for now. 

I believe the way we see the linked error is if an exception arises during the connection of the socket that doesn't prevent the socket from successfully connecting. In that case, `SetResult` will be getting called on a task completion source that has already completed due to the previous exception.

The downside of this PR is we decrease the chance of finding out the circumstances in which this occurs.