### PR TITLE
Upgrade code generator to new swagger format and properly pass server key to apple auth calls

### DIFF
--- a/codegen/main.go
+++ b/codegen/main.go
@@ -128,62 +128,63 @@ namespace Nakama
     {
         {{- range $propname, $property := $definition.Properties }}
         {{- $fieldname := $propname | pascalCase }}
+        {{- $attrDataName := $propname | snakeCase }}
 
         /// <inheritdoc />
         {{- if eq $property.Type "integer" }}
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public int {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "number" }}
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public double {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "boolean" }}
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public bool {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "string" }}
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public string {{ $fieldname }} { get; set; }
         {{- else if eq $property.Type "array" }}
             {{- if eq $property.Items.Type "string" }}
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public List<string> {{ $fieldname }} { get; set; }
             {{- else if eq $property.Items.Type "integer" }}
         [DataMember(Name="{{ $propname }}"), Preserve]
         public List<int> {{ $fieldname }} { get; set; }
             {{- else if eq $property.Items.Type "number" }}
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public List<double> {{ $fieldname }} { get; set; }
             {{- else if eq $property.Items.Type "boolean" }}
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public List<bool> {{ $fieldname }} { get; set; }
             {{- else}}
         public IEnumerable<I{{ $property.Items.Ref | cleanRef }}> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new List<{{ $property.Items.Ref | cleanRef }}>(0);
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public List<{{ $property.Items.Ref | cleanRef }}> _{{ $propname | camelCase }} { get; set; }
             {{- end }}
         {{- else if eq $property.Type "object"}}
             {{- if eq $property.AdditionalProperties.Type "string"}}
         public IDictionary<string, string> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, string>();
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public Dictionary<string, string> _{{ $propname | camelCase }} { get; set; }
             {{- else if eq $property.Items.Type "integer"}}
         public IDictionary<string, int> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, int>();
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
            {{- else if eq $property.Items.Type "number"}}
         public IDictionary<string, double> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, double>();
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public Dictionary<string, int> _{{ $propname | camelCase }} { get; set; }
             {{- else if eq $property.Items.Type "boolean"}}
         public IDictionary<string, bool> {{ $fieldname }} => _{{ $propname | camelCase }} ?? new Dictionary<string, bool>();
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public Dictionary<string, bool> _{{ $propname | camelCase }} { get; set; }
             {{- else}}
         public IDictionary<string, {{$property.AdditionalProperties | cleanRef}}> {{ $fieldname }}  => _{{ $propname | camelCase }} ?? new Dictionary<string, {{$property.AdditionalProperties | cleanRef}}>();
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public Dictionary<string, {{$property.AdditionalProperties | cleanRef}}> _{{ $propname | camelCase }} { get; set; }
             {{- end}}
         {{- else }}
         public I{{ $property.Ref | cleanRef }} {{ $fieldname }} => _{{ $propname | camelCase }};
-        [DataMember(Name="{{ $propname }}"), Preserve]
+        [DataMember(Name="{{ $attrDataName }}"), Preserve]
         public {{ $property.Ref | cleanRef }} _{{ $propname | camelCase }} { get; set; }
         {{- end }}
         {{- end }}
@@ -443,6 +444,20 @@ func snakeCaseToPascalCase(input string) (output string) {
 	return
 }
 
+func camelCaseToSnakeCase(input string) (output string) {
+	output = ""
+	for _, v := range input {
+		vString := string(v)
+		if vString == strings.ToUpper(vString) {
+			output += "_" + strings.ToLower(vString)
+		} else {
+			output += vString
+		}
+	}
+
+	return
+}
+
 func stripNewlines(input string) (output string) {
 	output = strings.Replace(input, "\n", " ", -1)
 	return
@@ -540,7 +555,9 @@ func main() {
 		"stripNewlines": stripNewlines,
 		"title":         strings.Title,
 		"uppercase":     strings.ToUpper,
+		"snakeCase":     camelCaseToSnakeCase,
 	}
+
 	tmpl, err := template.New(inputFile).Funcs(fmap).Parse(codeTemplate)
 	if err != nil {
 		fmt.Printf("Template parse error: %s\n", err)

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -298,9 +298,9 @@ namespace Nakama
         {
             {{- range $parameter := $operation.Parameters }}
             {{- if $parameter.Required }}
-            if ({{ $parameter.Name }} == null)
+            if ({{ $parameter.Name | camelCase}} == null)
             {
-                throw new ArgumentException("'{{ $parameter.Name }}' is required but was null.");
+                throw new ArgumentException("'{{ $parameter.Name | camelCase }}' is required but was null.");
             }
             {{- end }}
             {{- end }}

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Nakama Authors
+// Copyright 2020 The Nakama Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -273,8 +273,7 @@ namespace Nakama
             {{ $parameter.Schema.Ref | cleanRef }}{{- if not $parameter.Required }}?{{- end }} {{ $parameter.Name }}
             {{- end }}
         {{- else if eq $parameter.Type "array"}}
-            {{/* Current bug in Nakama  3d6b38d302b705305d8ae0f0b8e6c2255aabe5be forces us to camelcase "user_ids" */}}
-            IEnumerable<{{ $parameter.Items.Type | camelCase }}> {{ $parameter.Name }}
+            IEnumerable<{{ $parameter.Items.Type }}> {{ $parameter.Name | camelCase }}
         {{- else if eq $parameter.Type "object"}}
             {{- if eq $parameter.AdditionalProperties.Type "string"}}
         IDictionary<string, string> {{ $parameter.Name }}
@@ -444,8 +443,28 @@ func snakeCaseToPascalCase(input string) (output string) {
 	return
 }
 
+func isSnakeCase(input string) (output bool) {
+
+	output = true
+
+	for _, v := range input {
+		vString := string(v)
+		if strings.ToUpper(vString) == vString {
+			output = false
+		}
+	}
+
+	return
+}
+
 func camelCaseToSnakeCase(input string) (output string) {
 	output = ""
+
+	if isSnakeCase(input) {
+		output = input
+		return
+	}
+
 	for _, v := range input {
 		vString := string(v)
 		if vString == strings.ToUpper(vString) {

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -235,9 +235,9 @@ namespace Nakama
         /// {{ $operation.Summary | stripNewlines }}
         /// </summary>
         {{- if $operation.Responses.Ok.Schema.Ref }}
-        public async Task<I{{ $operation.Responses.Ok.Schema.Ref | cleanRef }}> {{ $operation.OperationId | pascalCase }}Async(
+        public async Task<I{{ $operation.Responses.Ok.Schema.Ref | cleanRef }}> {{ $operation.OperationId | stripOperationPrefix | pascalCase }}Async(
         {{- else }}
-        public async Task {{ $operation.OperationId | pascalCase }}Async(
+        public async Task {{ $operation.OperationId | stripOperationPrefix |pascalCase }}Async(
         {{- end}}
 
         {{- $isPreviousParam := false}}
@@ -463,6 +463,10 @@ func stripNewlines(input string) (output string) {
 	return
 }
 
+func stripOperationPrefix(input string) string {
+	return strings.Replace(input, "Nakama_", "", 1)
+}
+
 func main() {
 	// Argument flags
 	var output = flag.String("output", "", "The output for generated code.")
@@ -549,13 +553,14 @@ func main() {
 	}
 
 	fmap := template.FuncMap{
-		"camelCase":     snakeCaseToCamelCase,
-		"cleanRef":      convertRefToClassName,
-		"pascalCase":    snakeCaseToPascalCase,
-		"stripNewlines": stripNewlines,
-		"title":         strings.Title,
-		"uppercase":     strings.ToUpper,
-		"snakeCase":     camelCaseToSnakeCase,
+		"camelCase":            snakeCaseToCamelCase,
+		"cleanRef":             convertRefToClassName,
+		"pascalCase":           snakeCaseToPascalCase,
+		"stripNewlines":        stripNewlines,
+		"title":                strings.Title,
+		"uppercase":            strings.ToUpper,
+		"snakeCase":            camelCaseToSnakeCase,
+		"stripOperationPrefix": stripOperationPrefix,
 	}
 
 	tmpl, err := template.New(inputFile).Funcs(fmap).Parse(codeTemplate)

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -332,7 +332,7 @@ namespace Nakama
                 queryParams = string.Concat(queryParams, "{{- $snakecase }}=", {{ $parameter.Name }}.ToString().ToLower(), "&");
             }
                 {{- else if eq $parameter.Type "array" }}
-            foreach (var elem in {{ $parameter.Name }} ?? new {{ $parameter.Items.Type }}[0])
+            foreach (var elem in {{ $parameter.Name | camelCase }} ?? new {{ $parameter.Items.Type }}[0])
             {
                 queryParams = string.Concat(queryParams, "{{- $snakecase }}=", elem, "&");
             }
@@ -449,7 +449,7 @@ func isSnakeCase(input string) (output bool) {
 
 	for _, v := range input {
 		vString := string(v)
-		if strings.ToUpper(vString) == vString {
+		if vString != "_" && strings.ToUpper(vString) == vString {
 			output = false
 		}
 	}

--- a/src/Nakama/ApiClient.gen.cs
+++ b/src/Nakama/ApiClient.gen.cs
@@ -4347,8 +4347,8 @@ namespace Nakama
                 throw new ArgumentException("'channelId' is required but was null.");
             }
 
-            var urlpath = "/v2/channel/{channel_id}";
-            urlpath = urlpath.Replace("{channel_id}", Uri.EscapeDataString(channelId));
+            var urlpath = "/v2/channel/{channelId}";
+            urlpath = urlpath.Replace("{channelId}", Uri.EscapeDataString(channelId));
 
             var queryParams = "";
             if (limit != null) {
@@ -4679,8 +4679,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
 
@@ -4716,8 +4716,8 @@ namespace Nakama
                 throw new ArgumentException("'body' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
 
@@ -4751,8 +4751,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/add";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/add";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
             foreach (var elem in userIds ?? new string[0])
@@ -4788,8 +4788,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/ban";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/ban";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
             foreach (var elem in userIds ?? new string[0])
@@ -4829,8 +4829,8 @@ namespace Nakama
                 throw new ArgumentException("'userIds' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/demote";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/demote";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
             foreach (var elem in userIds ?? new string[0])
@@ -4865,8 +4865,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/join";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/join";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
 
@@ -4898,8 +4898,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/kick";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/kick";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
             foreach (var elem in userIds ?? new string[0])
@@ -4934,8 +4934,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/leave";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/leave";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
 
@@ -4967,8 +4967,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/promote";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/promote";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
             foreach (var elem in userIds ?? new string[0])
@@ -5006,8 +5006,8 @@ namespace Nakama
                 throw new ArgumentException("'groupId' is required but was null.");
             }
 
-            var urlpath = "/v2/group/{group_id}/user";
-            urlpath = urlpath.Replace("{group_id}", Uri.EscapeDataString(groupId));
+            var urlpath = "/v2/group/{groupId}/user";
+            urlpath = urlpath.Replace("{groupId}", Uri.EscapeDataString(groupId));
 
             var queryParams = "";
             if (limit != null) {
@@ -5048,8 +5048,8 @@ namespace Nakama
                 throw new ArgumentException("'leaderboardId' is required but was null.");
             }
 
-            var urlpath = "/v2/leaderboard/{leaderboard_id}";
-            urlpath = urlpath.Replace("{leaderboard_id}", Uri.EscapeDataString(leaderboardId));
+            var urlpath = "/v2/leaderboard/{leaderboardId}";
+            urlpath = urlpath.Replace("{leaderboardId}", Uri.EscapeDataString(leaderboardId));
 
             var queryParams = "";
 
@@ -5084,8 +5084,8 @@ namespace Nakama
                 throw new ArgumentException("'leaderboardId' is required but was null.");
             }
 
-            var urlpath = "/v2/leaderboard/{leaderboard_id}";
-            urlpath = urlpath.Replace("{leaderboard_id}", Uri.EscapeDataString(leaderboardId));
+            var urlpath = "/v2/leaderboard/{leaderboardId}";
+            urlpath = urlpath.Replace("{leaderboardId}", Uri.EscapeDataString(leaderboardId));
 
             var queryParams = "";
             foreach (var elem in ownerIds ?? new string[0])
@@ -5135,8 +5135,8 @@ namespace Nakama
                 throw new ArgumentException("'body' is required but was null.");
             }
 
-            var urlpath = "/v2/leaderboard/{leaderboard_id}";
-            urlpath = urlpath.Replace("{leaderboard_id}", Uri.EscapeDataString(leaderboardId));
+            var urlpath = "/v2/leaderboard/{leaderboardId}";
+            urlpath = urlpath.Replace("{leaderboardId}", Uri.EscapeDataString(leaderboardId));
 
             var queryParams = "";
 
@@ -5177,9 +5177,9 @@ namespace Nakama
                 throw new ArgumentException("'ownerId' is required but was null.");
             }
 
-            var urlpath = "/v2/leaderboard/{leaderboard_id}/owner/{owner_id}";
-            urlpath = urlpath.Replace("{leaderboard_id}", Uri.EscapeDataString(leaderboardId));
-            urlpath = urlpath.Replace("{owner_id}", Uri.EscapeDataString(ownerId));
+            var urlpath = "/v2/leaderboard/{leaderboardId}/owner/{ownerId}";
+            urlpath = urlpath.Replace("{leaderboardId}", Uri.EscapeDataString(leaderboardId));
+            urlpath = urlpath.Replace("{ownerId}", Uri.EscapeDataString(ownerId));
 
             var queryParams = "";
             if (limit != null) {
@@ -5574,9 +5574,9 @@ namespace Nakama
                 throw new ArgumentException("'userId' is required but was null.");
             }
 
-            var urlpath = "/v2/storage/{collection}/{user_id}";
+            var urlpath = "/v2/storage/{collection}/{userId}";
             urlpath = urlpath.Replace("{collection}", Uri.EscapeDataString(collection));
-            urlpath = urlpath.Replace("{user_id}", Uri.EscapeDataString(userId));
+            urlpath = urlpath.Replace("{userId}", Uri.EscapeDataString(userId));
 
             var queryParams = "";
             if (limit != null) {
@@ -5669,8 +5669,8 @@ namespace Nakama
                 throw new ArgumentException("'tournamentId' is required but was null.");
             }
 
-            var urlpath = "/v2/tournament/{tournament_id}";
-            urlpath = urlpath.Replace("{tournament_id}", Uri.EscapeDataString(tournamentId));
+            var urlpath = "/v2/tournament/{tournamentId}";
+            urlpath = urlpath.Replace("{tournamentId}", Uri.EscapeDataString(tournamentId));
 
             var queryParams = "";
             foreach (var elem in ownerIds ?? new string[0])
@@ -5720,8 +5720,8 @@ namespace Nakama
                 throw new ArgumentException("'body' is required but was null.");
             }
 
-            var urlpath = "/v2/tournament/{tournament_id}";
-            urlpath = urlpath.Replace("{tournament_id}", Uri.EscapeDataString(tournamentId));
+            var urlpath = "/v2/tournament/{tournamentId}";
+            urlpath = urlpath.Replace("{tournamentId}", Uri.EscapeDataString(tournamentId));
 
             var queryParams = "";
 
@@ -5755,8 +5755,8 @@ namespace Nakama
                 throw new ArgumentException("'tournamentId' is required but was null.");
             }
 
-            var urlpath = "/v2/tournament/{tournament_id}/join";
-            urlpath = urlpath.Replace("{tournament_id}", Uri.EscapeDataString(tournamentId));
+            var urlpath = "/v2/tournament/{tournamentId}/join";
+            urlpath = urlpath.Replace("{tournamentId}", Uri.EscapeDataString(tournamentId));
 
             var queryParams = "";
 
@@ -5794,9 +5794,9 @@ namespace Nakama
                 throw new ArgumentException("'ownerId' is required but was null.");
             }
 
-            var urlpath = "/v2/tournament/{tournament_id}/owner/{owner_id}";
-            urlpath = urlpath.Replace("{tournament_id}", Uri.EscapeDataString(tournamentId));
-            urlpath = urlpath.Replace("{owner_id}", Uri.EscapeDataString(ownerId));
+            var urlpath = "/v2/tournament/{tournamentId}/owner/{ownerId}";
+            urlpath = urlpath.Replace("{tournamentId}", Uri.EscapeDataString(tournamentId));
+            urlpath = urlpath.Replace("{ownerId}", Uri.EscapeDataString(ownerId));
 
             var queryParams = "";
             if (limit != null) {
@@ -5879,8 +5879,8 @@ namespace Nakama
                 throw new ArgumentException("'userId' is required but was null.");
             }
 
-            var urlpath = "/v2/user/{user_id}/group";
-            urlpath = urlpath.Replace("{user_id}", Uri.EscapeDataString(userId));
+            var urlpath = "/v2/user/{userId}/group";
+            urlpath = urlpath.Replace("{userId}", Uri.EscapeDataString(userId));
 
             var queryParams = "";
             if (limit != null) {

--- a/src/Nakama/ApiClient.gen.cs
+++ b/src/Nakama/ApiClient.gen.cs
@@ -3184,7 +3184,7 @@ namespace Nakama
     /// <summary>
     /// 
     /// </summary>
-    public interface IRuntimeError
+    public interface IRpcStatus
     {
 
         /// <summary>
@@ -3200,16 +3200,11 @@ namespace Nakama
         /// <summary>
         /// 
         /// </summary>
-        string Error { get; }
-
-        /// <summary>
-        /// 
-        /// </summary>
         string Message { get; }
     }
 
     /// <inheritdoc />
-    internal class RuntimeError : IRuntimeError
+    internal class RpcStatus : IRpcStatus
     {
 
         /// <inheritdoc />
@@ -3222,10 +3217,6 @@ namespace Nakama
         public List<ProtobufAny> _details { get; set; }
 
         /// <inheritdoc />
-        [DataMember(Name="error"), Preserve]
-        public string Error { get; set; }
-
-        /// <inheritdoc />
         [DataMember(Name="message"), Preserve]
         public string Message { get; set; }
 
@@ -3234,7 +3225,6 @@ namespace Nakama
             var output = "";
             output = string.Concat(output, "Code: ", Code, ", ");
             output = string.Concat(output, "Details: [", string.Join(", ", Details), "], ");
-            output = string.Concat(output, "Error: ", Error, ", ");
             output = string.Concat(output, "Message: ", Message, ", ");
             return output;
         }

--- a/src/Nakama/ApiClient.gen.cs
+++ b/src/Nakama/ApiClient.gen.cs
@@ -3338,7 +3338,9 @@ namespace Nakama
         public async Task<IApiSession> AuthenticateAppleAsync(
             string basicAuthUsername,
             string basicAuthPassword,
-            ApiAccountApple body)
+            ApiAccountApple body,
+            bool? create,
+            string username)
         {
             if (body == null)
             {
@@ -3348,6 +3350,12 @@ namespace Nakama
             var urlpath = "/v2/account/authenticate/apple";
 
             var queryParams = "";
+            if (create != null) {
+                queryParams = string.Concat(queryParams, "create=", create.ToString().ToLower(), "&");
+            }
+            if (username != null) {
+                queryParams = string.Concat(queryParams, "username=", Uri.EscapeDataString(username), "&");
+            }
 
             var uri = new UriBuilder(_baseUri)
             {

--- a/src/Nakama/ApiClient.gen.cs
+++ b/src/Nakama/ApiClient.gen.cs
@@ -5362,7 +5362,8 @@ namespace Nakama
         public async Task<IApiRpc> RpcFuncAsync(
             string bearerToken,
             string id,
-            string body)
+            string body,
+            string httpKey)
         {
             if (id == null)
             {
@@ -5377,6 +5378,9 @@ namespace Nakama
             urlpath = urlpath.Replace("{id}", Uri.EscapeDataString(id));
 
             var queryParams = "";
+            if (httpKey != null) {
+                queryParams = string.Concat(queryParams, "http_key=", Uri.EscapeDataString(httpKey), "&");
+            }
 
             var uri = new UriBuilder(_baseUri)
             {

--- a/src/Nakama/Client.cs
+++ b/src/Nakama/Client.cs
@@ -96,8 +96,8 @@ namespace Nakama
         }
 
         /// <inheritdoc cref="AuthenticateAppleAsync"/>
-        public async Task<ISession> AuthenticateAppleAsync(string username, string token, Dictionary<string, string> vars) {
-            var response = await _apiClient.AuthenticateAppleAsync(username, string.Empty, new ApiAccountApple {Token = token, _vars = vars});
+        public async Task<ISession> AuthenticateAppleAsync(string token, string username = null, bool create = true, Dictionary<string, string> vars = null) {
+            var response = await _apiClient.AuthenticateAppleAsync(ServerKey, string.Empty, new ApiAccountApple {Token = token, _vars = vars}, create, username);
             return new Session(response.Token, response.Created);
         }
 

--- a/src/Nakama/Client.cs
+++ b/src/Nakama/Client.cs
@@ -428,7 +428,7 @@ namespace Nakama
 
         /// <inheritdoc cref="RpcAsync(Nakama.ISession,string,string)"/>
         public Task<IApiRpc> RpcAsync(ISession session, string id, string payload) =>
-            _apiClient.RpcFuncAsync(session.AuthToken, id, payload);
+            _apiClient.RpcFuncAsync(session.AuthToken, id, payload, null);
 
         /// <inheritdoc cref="RpcAsync(Nakama.ISession,string)"/>
         public Task<IApiRpc> RpcAsync(ISession session, string id) =>

--- a/src/Nakama/IClient.cs
+++ b/src/Nakama/IClient.cs
@@ -75,7 +75,7 @@ namespace Nakama
         /// <param name="token">The ID token received from Apple to validate.</param>
         /// <param name="vars">Extra information that will be bundled in the session token.</param>
         /// <returns>A task which resolves to a session object.</returns>
-        Task<ISession> AuthenticateAppleAsync(string username, string token, Dictionary<string, string> vars);
+        Task<ISession> AuthenticateAppleAsync(string token, string username = null, bool create = true, Dictionary<string, string> vars = null);
 
         /// <summary>
         /// Authenticate a user with a custom id.

--- a/tests/Nakama.Tests/AuthenticateTest.cs
+++ b/tests/Nakama.Tests/AuthenticateTest.cs
@@ -116,8 +116,8 @@ namespace Nakama.Tests.Api
         public async void ShouldNotAuthenticateApple()
         {
             // Fails because Apple requires special configuration with the server.
-            var ex = await Assert.ThrowsAsync<ApiResponseException>(() => _client.AuthenticateAppleAsync("some_username", "some_token", new Dictionary<string, string>()));
-            Assert.Equal((int) HttpStatusCode.Unauthorized, ex.StatusCode);
+            var ex = await Assert.ThrowsAsync<ApiResponseException>(() => _client.AuthenticateAppleAsync("some_token"));
+            Assert.Equal((int) HttpStatusCode.BadRequest, ex.StatusCode);
         }
     }
 }

--- a/tests/Nakama.Tests/HttpErrorTest.cs
+++ b/tests/Nakama.Tests/HttpErrorTest.cs
@@ -83,22 +83,5 @@ namespace Nakama.Tests.Api
             // go runtime returns an empty object
             Assert.Empty(exception.Data);
         }
-
-        [Fact]
-        public async Task BadLuaStorageRpcReturnsErrorMessageAndStringNotDict()
-        {
-            var session = await _client.AuthenticateCustomAsync("user_rpc_error_storage_lua");
-            const string funcid = "clientrpc.rpc_storage_error";
-
-            var exception = await Assert.ThrowsAsync<ApiResponseException>(() => _client.RpcAsync(session, funcid, session.UserId));
-            await Assert.ThrowsAsync<ApiResponseException>(() => _client.RpcAsync(session, funcid));
-            Assert.NotNull(exception.Message);
-            Assert.NotEmpty(exception.Message);
-             //lua runtime differs from go runtime in returning error as string.
-            Assert.True(exception.Data.Contains("error"));
-            Assert.NotNull(exception.Data["error"] as string);
-            Assert.NotEmpty(exception.Data["error"] as string);
-
-        }
     }
 }


### PR DESCRIPTION
- Resolves an Apple Authentication bug where the server key was not passed to our `AuthenticateAppleAsync` method: https://forum.heroiclabs.com/t/issue-with-authenticateappleasync-from-quick-login/1034/16
- Also includes updates to the apple authentication signature and the rpc call signature. `httpkey` is now a required parameter for the latter.
- Upgrades the code generator to new requirements introduced by Nakama 2.14 https://github.com/heroiclabs/nakama/releases/tag/v2.14.0 You'll see a lot of futzing with casing -- in short, our swagger doc now formats parameters to service calls in camel case by default rather than snake case. So you'll see compensation for that. The notable exception is `user_ids` which has stubbornly remained snake case by default.