### PR TITLE
New types added to TinyJson

### DIFF
--- a/src/Nakama/TinyJson/JsonParser.cs
+++ b/src/Nakama/TinyJson/JsonParser.cs
@@ -217,6 +217,20 @@ namespace Nakama.TinyJson
                 return result;
             }
 
+            if (type == typeof(DateTime))
+            {
+                DateTime result;
+                DateTime.TryParse(json.Replace("\"", string.Empty), out result);
+                return result;
+            }
+
+            if (type == typeof(Guid))
+            {
+                Guid result;
+                Guid.TryParse(json.Replace("\"", string.Empty), out result);
+                return result;
+            }
+
             if (json == "null")
             {
                 return null;

--- a/src/Nakama/TinyJson/JsonWriter.cs
+++ b/src/Nakama/TinyJson/JsonWriter.cs
@@ -101,6 +101,14 @@ namespace Nakama.TinyJson
             {
                 stringBuilder.Append((bool) item ? "true" : "false");
             }
+            else if (type == typeof(System.DateTime))
+            {
+                stringBuilder.Append("\"" + item + "\"");
+            }
+            else if (type == typeof(System.Guid))
+            {
+                stringBuilder.Append("\"" + item + "\"");
+            }
             else if (type.IsEnum)
             {
                 stringBuilder.Append('"');

--- a/src/Nakama/TinyJson/JsonWriter.cs
+++ b/src/Nakama/TinyJson/JsonWriter.cs
@@ -103,7 +103,7 @@ namespace Nakama.TinyJson
             }
             else if (type == typeof(System.DateTime))
             {
-                stringBuilder.Append("\"" + item + "\"");
+                stringBuilder.Append("\"" + ((DateTime)item).ToString("yyyy-MM-ddTHH:mm:ss.fffffffK") + "\"");
             }
             else if (type == typeof(System.Guid))
             {

--- a/tests/Nakama.Tests/TinyJsonParserTest.cs
+++ b/tests/Nakama.Tests/TinyJsonParserTest.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using Nakama.TinyJson;
 using Xunit;
+using System;
 
 namespace Nakama.Tests
 {
@@ -27,19 +28,20 @@ namespace Nakama.Tests
         [Fact]
         public void FromJson_JsonInput_Parsed()
         {
-            const string json = @"{""some_val"": ""val1"", ""nested"": [{""another_val"": ""val2""}]}";
+            const string json = @"{""some_val"": ""val1"", ""nested"": [{""another_val"": ""val2"", ""date_val"":""2/16/2021 3:28:34 PM""}]}";
             ITestObject result = json.FromJson<TestObject>();
 
             Assert.Equal("val1", result.SomeVal);
             Assert.Equal("val2", result.Nested.First().AnotherVal);
+            Assert.Equal(Convert.ToDateTime("2/16/2021 3:28:34 PM"), result.Nested.First().DateVal);
         }
 
         [Fact]
         public void FromJson_JsonInput_ParsedTwice()
         {
-            const string json1 = @"{""some_val"": ""val1"", ""nested"": [{""another_val"": ""val2""}]}";
+            const string json1 = @"{""some_val"": ""val1"", ""nested"": [{""another_val"": ""val2"", ""date_val"":""2/16/2021 3:28:34 PM""}]}";
             ITestObject result1 = json1.FromJson<TestObject>();
-            const string json2 = @"{""some_val"": ""val1"", ""nested"": [{""another_val"": ""val2""}]}";
+            const string json2 = @"{""some_val"": ""val1"", ""nested"": [{""another_val"": ""val2"", ""date_val"":""2/16/2021 3:28:34 PM""}]}";
             ITestObject result2 = json2.FromJson<TestObject>();
 
             Assert.Equal(result1.SomeVal, result2.SomeVal);
@@ -55,11 +57,11 @@ namespace Nakama.Tests
 
     internal class TestObject : ITestObject
     {
-        [DataMember(Name="some_val")]
+        [DataMember(Name = "some_val")]
         public string SomeVal { get; set; }
 
         public IEnumerable<INestedTestObject> Nested => _nested ?? new List<NestedTestObject>(0);
-        [DataMember(Name="nested")]
+        [DataMember(Name = "nested")]
         // ReSharper disable once InconsistentNaming
         public List<NestedTestObject> _nested { get; set; }
     }
@@ -67,11 +69,15 @@ namespace Nakama.Tests
     public interface INestedTestObject
     {
         string AnotherVal { get; }
+        DateTime DateVal { get; }
     }
 
     internal class NestedTestObject : INestedTestObject
     {
-        [DataMember(Name="another_val")]
+        [DataMember(Name = "another_val")]
         public string AnotherVal { get; set; }
+
+        [DataMember(Name = "date_val")]
+        public DateTime DateVal { get; set; }
     }
 }

--- a/tests/Nakama.Tests/TinyJsonParserTest.cs
+++ b/tests/Nakama.Tests/TinyJsonParserTest.cs
@@ -46,6 +46,29 @@ namespace Nakama.Tests
 
             Assert.Equal(result1.SomeVal, result2.SomeVal);
         }
+        
+        [Fact]
+        public void FromObject_ToObject()
+        {
+            TestObjectWithAllTypes testObject = new TestObjectWithAllTypes();
+            testObject.UUID = Guid.NewGuid();
+            testObject.IntVal = 1;
+            testObject.DateTimeVal = DateTime.Now;
+            testObject.BoolVal = true;
+            testObject.FloatVal = 1.1F;
+            testObject.Stringval = "Good Work";
+
+            string json = testObject.ToJson();
+
+            TestObjectWithAllTypes testObjectFromJson = json.FromJson<TestObjectWithAllTypes>();
+
+            Assert.Equal(testObject.UUID, testObjectFromJson.UUID);
+            Assert.Equal(testObject.IntVal, testObjectFromJson.IntVal);
+            Assert.Equal(testObject.DateTimeVal, testObjectFromJson.DateTimeVal);
+            Assert.Equal(testObject.BoolVal, testObjectFromJson.BoolVal);
+            Assert.Equal(testObject.FloatVal, testObjectFromJson.FloatVal);
+            Assert.Equal(testObject.Stringval, testObjectFromJson.Stringval);
+        }
     }
 
     public interface ITestObject
@@ -79,5 +102,15 @@ namespace Nakama.Tests
 
         [DataMember(Name = "date_val")]
         public DateTime DateVal { get; set; }
+    }
+    
+    internal class TestObjectWithAllTypes
+    {
+        public Guid UUID { get; set; }
+        public int IntVal { get; set; }
+        public DateTime DateTimeVal { get; set; }
+        public bool BoolVal { get; set; }
+        public float FloatVal { get; set; }
+        public string Stringval { get; set; }
     }
 }


### PR DESCRIPTION
TinyJson does not work when object has a DateTime and Guid. The type conversions added to TinyJson. Also tests are modified.