### PR TITLE
Allow the language tag to be set on the socket on connect.

### DIFF
--- a/src/Nakama/ISocket.cs
+++ b/src/Nakama/ISocket.cs
@@ -181,9 +181,10 @@ namespace Nakama
         /// <param name="session">The session of the user.</param>
         /// <param name="appearOnline">If the user who appear online to other users.</param>
         /// <param name="connectTimeout">The time allowed for the socket connection to be established.</param>
+        /// <param name="langTag">The language tag of the user on the connected socket.</param>
         /// <returns>A task to represent the asynchronous operation.</returns>
         Task ConnectAsync(ISession session, bool appearOnline = false,
-            int connectTimeout = Socket.DefaultConnectTimeout);
+            int connectTimeout = Socket.DefaultConnectTimeout, string langTag = "en");
 
         /// <summary>
         /// Create a multiplayer match on the server.

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -240,7 +240,7 @@ namespace Nakama
 
         /// <inheritdoc cref="ConnectAsync"/>
         public Task ConnectAsync(ISession session, bool appearOnline = false,
-            int connectTimeoutSec = DefaultConnectTimeout)
+            int connectTimeoutSec = DefaultConnectTimeout, string langTag = "en")
         {
             var tcs = new TaskCompletionSource<bool>();
             Action callback = () => tcs.TrySetResult(true);
@@ -250,7 +250,7 @@ namespace Nakama
             var uri = new UriBuilder(_baseUri)
             {
                 Path = "/ws",
-                Query = $"lang=en&status={appearOnline}&token={session.AuthToken}"
+                Query = $"lang={langTag}&status={appearOnline}&token={session.AuthToken}"
             }.Uri;
             tcs.Task.ContinueWith(_ =>
             {


### PR DESCRIPTION
This field can be extracted server-side in the context object of RPCs, hooks, and other parts of the server framework when its needed to be passed to a separate service. A good use case is with profanity filters which need information on the language of the chat message to be filtered.
