### PR TITLE
Automated socket reconnect

### DIFF
--- a/src/Nakama/ISocket.cs
+++ b/src/Nakama/ISocket.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 The Nakama Authors
+// Copyright 2021 The Nakama Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nakama
@@ -183,9 +184,10 @@ namespace Nakama
         /// <param name="connectTimeout">The time allowed for the socket connection to be established.</param>
         /// <param name="langTag">The language tag of the user on the connected socket.</param>
         /// <param name="retryConfiguration">The <see cref="RetryConfiguration"/> to use if the socket connection fails due to a transient network error.</param>
+        /// <param name="canceller">The <see cref="CancellationTokenSource"/> that can be used to cancel the connection request while mid-flight.</param>
         /// <returns>A task to represent the asynchronous operation.</returns>
         Task ConnectAsync(ISession session, bool appearOnline = false,
-            int connectTimeout = Socket.DefaultConnectTimeout, string langTag = "en", RetryConfiguration retryConfiguration = null);
+            int connectTimeout = Socket.DefaultConnectTimeout, string langTag = "en", RetryConfiguration retryConfiguration = null, CancellationTokenSource canceller = null);
 
         /// <summary>
         /// Create a multiplayer match on the server.

--- a/src/Nakama/ISocket.cs
+++ b/src/Nakama/ISocket.cs
@@ -182,9 +182,10 @@ namespace Nakama
         /// <param name="appearOnline">If the user who appear online to other users.</param>
         /// <param name="connectTimeout">The time allowed for the socket connection to be established.</param>
         /// <param name="langTag">The language tag of the user on the connected socket.</param>
+        /// <param name="retryConfiguration">The <see cref="RetryConfiguration"/> to use if the socket connection fails due to a transient network error.</param>
         /// <returns>A task to represent the asynchronous operation.</returns>
         Task ConnectAsync(ISession session, bool appearOnline = false,
-            int connectTimeout = Socket.DefaultConnectTimeout, string langTag = "en");
+            int connectTimeout = Socket.DefaultConnectTimeout, string langTag = "en", RetryConfiguration retryConfiguration = null);
 
         /// <summary>
         /// Create a multiplayer match on the server.

--- a/src/Nakama/ISocketAdapter.cs
+++ b/src/Nakama/ISocketAdapter.cs
@@ -64,7 +64,8 @@ namespace Nakama
         /// </summary>
         /// <param name="uri">The URI of the server.</param>
         /// <param name="timeout">The timeout for the connect attempt on the socket.</param>
-        void Connect(Uri uri, int timeout);
+        /// <param name="canceller">The <see cref="CancellationTokenSource"/> that can be used to cancel the connection request while mid-flight.</param>
+        void Connect(Uri uri, int timeout, CancellationTokenSource canceller);
 
         /// <summary>
         /// Send data to the server with an asynchronous operation.

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -81,7 +81,8 @@ namespace Nakama
         {
             return (e is ApiResponseException apiException && apiException.StatusCode >= 500)
             || e is HttpRequestException
-            || e is SocketException;
+            || e is SocketException
+            || e is System.IO.EndOfStreamException;
         }
 
         private Retry CreateNewRetry(RetryHistory history)

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -78,7 +78,8 @@ namespace Nakama
         /// </summary>
         private bool IsTransientException(Exception e)
         {
-            return (e is ApiResponseException apiException && apiException.StatusCode >= 500) || e is HttpRequestException;
+            return (e is ApiResponseException apiException && apiException.StatusCode >= 500)
+            || e is HttpRequestException;
         }
 
         private Retry CreateNewRetry(RetryHistory history)

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace Nakama
@@ -79,7 +80,8 @@ namespace Nakama
         private bool IsTransientException(Exception e)
         {
             return (e is ApiResponseException apiException && apiException.StatusCode >= 500)
-            || e is HttpRequestException;
+            || e is HttpRequestException
+            || e is SocketException;
         }
 
         private Retry CreateNewRetry(RetryHistory history)

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -81,8 +81,7 @@ namespace Nakama
         {
             return (e is ApiResponseException apiException && apiException.StatusCode >= 500)
             || e is HttpRequestException
-            || e is SocketException
-            || e is System.IO.EndOfStreamException;
+            || e is System.IO.IOException; // thrown if error during socket handshake (AsyncProtocolRequest)
         }
 
         private Retry CreateNewRetry(RetryHistory history)

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -198,11 +198,11 @@ namespace Nakama
 
             var history = new RetryHistory(retryConfiguration ?? _defaultConnectRetryConfig, userCancelToken: canceller?.Token);
 
-            Task retry = _retryInvoker.InvokeWithRetry(() => ConnectAsync(uri, connectTimeoutSec, canceller), history);
+            Task connect = _retryInvoker.InvokeWithRetry(() => ConnectAsync(uri, connectTimeoutSec, canceller), history);
 
-            await retry;
+            await connect;
 
-            if (!retry.IsFaulted)
+            if (!connect.IsFaulted)
             {
                 Action<Exception> retryCallback = e =>
                 {

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -759,7 +759,7 @@ namespace Nakama
         {
             var scheme = client.Scheme.ToLower().Equals("http") ? "ws" : "wss";
             // TODO improve how logger is passed into socket object.
-            return new Socket(scheme, client.Host, client.Port, adapter) {Logger = (client as Client)?.Logger};
+            return new Socket(scheme, client.Host, client.Port, adapter, autoReconnect: false) {Logger = (client as Client)?.Logger};
         }
 
         private void ReceivedMessage(ArraySegment<byte> buffer)

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -120,7 +120,7 @@ namespace Nakama
         /// <summary>
         /// A new socket with default options.
         /// </summary>
-        public Socket() : this(Client.DefaultScheme, Client.DefaultHost, Client.DefaultPort, new WebSocketAdapter(), autoReconnect: true)
+        public Socket() : this(Client.DefaultScheme, Client.DefaultHost, Client.DefaultPort, new WebSocketAdapter(), autoReconnect: false)
         {
         }
 
@@ -129,7 +129,7 @@ namespace Nakama
         /// </summary>
         /// <param name="adapter">The adapter for use with the socket.</param>
         public Socket(ISocketAdapter adapter) : this(Client.DefaultScheme, Client.DefaultHost, Client.DefaultPort,
-            adapter, autoReconnect: true)
+            adapter, autoReconnect: false)
         {
         }
 

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -103,6 +103,7 @@ namespace Nakama
         public ILogger Logger { get; set; }
 
         private readonly ISocketAdapter _adapter;
+        private readonly bool _autoReconnect;
         private readonly Uri _baseUri;
         private readonly Dictionary<string, TaskCompletionSource<WebSocketMessageEnvelope>> _responses;
 
@@ -119,7 +120,7 @@ namespace Nakama
         /// <summary>
         /// A new socket with default options.
         /// </summary>
-        public Socket() : this(Client.DefaultScheme, Client.DefaultHost, Client.DefaultPort, new WebSocketAdapter())
+        public Socket() : this(Client.DefaultScheme, Client.DefaultHost, Client.DefaultPort, new WebSocketAdapter(), autoReconnect: true)
         {
         }
 
@@ -128,7 +129,7 @@ namespace Nakama
         /// </summary>
         /// <param name="adapter">The adapter for use with the socket.</param>
         public Socket(ISocketAdapter adapter) : this(Client.DefaultScheme, Client.DefaultHost, Client.DefaultPort,
-            adapter)
+            adapter, autoReconnect: true)
         {
         }
 
@@ -139,10 +140,12 @@ namespace Nakama
         /// <param name="host">The host address of the server.</param>
         /// <param name="port">The port number of the server.</param>
         /// <param name="adapter">The adapter for use with the socket.</param>
-        public Socket(string scheme, string host, int port, ISocketAdapter adapter)
+        /// <param name="autoReconnect">Whether or not the socket should reconnect upon a transient disconnect.</param>
+        public Socket(string scheme, string host, int port, ISocketAdapter adapter, bool autoReconnect)
         {
             Logger = NullLogger.Instance;
             _adapter = adapter;
+            _autoReconnect = autoReconnect;
             _baseUri = new UriBuilder(scheme, host, port).Uri;
             _responses = new Dictionary<string, TaskCompletionSource<WebSocketMessageEnvelope>>();
 

--- a/tests/Nakama.Tests/Socket/TransientExceptionSocketAdapter.cs
+++ b/tests/Nakama.Tests/Socket/TransientExceptionSocketAdapter.cs
@@ -1,0 +1,104 @@
+/**
+* Copyright 2021 The Nakama Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Nakama.Tests
+{
+    /// <summary>
+    /// An adapter which throws transient/retryable exceptions when a socket communicates with the server.
+    /// </summary>
+    public class TransientExceptionSocketAdapter : ISocketAdapter
+    {
+        public class NetworkSchedule
+        {
+            public TransientAdapterResponseType[] ConnectResponses { get; }
+            public List<Tuple<TimeSpan, TransientAdapterResponseType>> PostConnect { get; }
+
+            public NetworkSchedule(TransientAdapterResponseType[] connectResponses)
+            {
+                ConnectResponses = connectResponses;
+                PostConnect = new List<Tuple<TimeSpan, TransientAdapterResponseType>>();
+            }
+
+            public NetworkSchedule(TransientAdapterResponseType[] connect, List<Tuple<TimeSpan, TransientAdapterResponseType>> postConnect)
+            {
+                ConnectResponses = connect;
+                PostConnect = postConnect;
+            }
+        }
+
+        public bool IsConnected { get; private set; }
+        public bool IsConnecting { get; private set; }
+
+        public event Action Connected;
+        public event Action Closed;
+
+        public event Action<Exception> ReceivedError;
+        public event Action<ArraySegment<byte>> Received;
+
+        private NetworkSchedule _schedule;
+        private int _numConnectAttempts;
+
+        public TransientExceptionSocketAdapter(NetworkSchedule schedule)
+        {
+            _schedule = schedule;
+        }
+
+        public void Close()
+        {
+            Closed?.Invoke();
+        }
+
+        public async void Connect(Uri uri, int timeout, CancellationTokenSource canceller)
+        {
+            canceller.Token.ThrowIfCancellationRequested();
+
+            if (_schedule.ConnectResponses[_numConnectAttempts] == TransientAdapterResponseType.ServerOk)
+            {
+                _numConnectAttempts++;
+                IsConnected = true;
+                Connected?.Invoke();
+            }
+            else
+            {
+                System.Console.WriteLine("throwing a connect exception");
+                _numConnectAttempts++;
+                ReceivedError?.Invoke(new System.IO.IOException("Connect exception."));
+            }
+
+            foreach (var postConnect in _schedule.PostConnect)
+            {
+                await Task.Delay(postConnect.Item1);
+
+                if (postConnect.Item2 == TransientAdapterResponseType.TransientError)
+                {
+                    ReceivedError?.Invoke(new System.IO.IOException("Post connect exception."));
+                }
+            }
+        }
+
+        public void Dispose() {}
+
+        public void Send(ArraySegment<byte> buffer, CancellationToken cancellationToken, bool reliable = true)
+        {
+            throw new NotImplementedException("This adapter cannot send messages.");
+        }
+    }
+}


### PR DESCRIPTION
- Adds retry and cancellation token to the actual connect operation
- Adds connect with retry if the socket disconnects due to an `IOException.`
- Defaults `autoReconnect` to `false`. The reason I did this is in case users have existing code doing socket reconnects. If they upgrade and forgot to change a `true` parameter, they would be "double reconnecting" in the case of disconnects.