### PR TITLE
Refactor WebSocket and Ninja Websocket Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Refactored the web socket. Changes should be backwards compatible except for the following:
+    - Exceptions occuring in the socket that were previously left unobserved are now observable via the `ReceivedError` event.
+    - Users who were catching `WebSocketException` to check if an incoming frame size was too large for the socket receive buffer should now catch `InternalBufferOverflowException` instead.
+    - Users who try to send data over a disconnected socket will now receive a `WebSocketException`.
+
 ## [3.2.0] - 2021-10-11
 ### Added
 - Added additional group listing filters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
     - Exceptions occuring in the socket that were previously left unobserved are now observable via the `ReceivedError` event.
     - Users who were catching `WebSocketException` to check if an incoming frame size was too large for the socket receive buffer should now catch `InternalBufferOverflowException` instead.
     - Users who try to send data over a disconnected socket will now receive a `WebSocketException`.
+    - Users who try to connect to an already-connected socket will no longer receive an exception. Instead
+    a warning will be printed and the connect will return early.
 
 ## [3.2.0] - 2021-10-11
 ### Added

--- a/src/Nakama/ISocket.cs
+++ b/src/Nakama/ISocket.cs
@@ -21,7 +21,7 @@ namespace Nakama
     /// <summary>
     /// A socket to interact with Nakama server.
     /// </summary>
-    public interface ISocket : IDisposable
+    public interface ISocket
     {
         /// <summary>
         /// Received when a socket is closed.

--- a/src/Nakama/ISocketAdapter.cs
+++ b/src/Nakama/ISocketAdapter.cs
@@ -23,7 +23,7 @@ namespace Nakama
     /// <summary>
     /// An adapter which implements a socket with a protocol supported by Nakama.
     /// </summary>
-    public interface ISocketAdapter : IDisposable
+    public interface ISocketAdapter
     {
         /// <summary>
         /// An event dispatched when the socket is disconnected.

--- a/src/Nakama/ISocketAdapter.cs
+++ b/src/Nakama/ISocketAdapter.cs
@@ -43,7 +43,7 @@ namespace Nakama
         /// <summary>
         /// Close the socket with an asynchronous operation.
         /// </summary>
-        void Close();
+        Task Close();
 
         /// <summary>
         /// Connect to the server with an asynchronous operation.

--- a/src/Nakama/ISocketAdapter.cs
+++ b/src/Nakama/ISocketAdapter.cs
@@ -26,11 +26,6 @@ namespace Nakama
     public interface ISocketAdapter : IDisposable
     {
         /// <summary>
-        /// An event dispatched when the socket is connected.
-        /// </summary>
-        event Action Connected;
-
-        /// <summary>
         /// An event dispatched when the socket is disconnected.
         /// </summary>
         event Action Closed;
@@ -44,16 +39,6 @@ namespace Nakama
         /// An event dispatched when the socket receives a message.
         /// </summary>
         event Action<ArraySegment<byte>> Received;
-
-        /// <summary>
-        /// If the socket is connected.
-        /// </summary>
-        bool IsConnected { get; }
-
-        /// <summary>
-        /// If the socket is connecting.
-        /// </summary>
-        bool IsConnecting { get; }
 
         /// <summary>
         /// Close the socket with an asynchronous operation.

--- a/src/Nakama/ISocketAdapter.cs
+++ b/src/Nakama/ISocketAdapter.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nakama
 {
@@ -64,7 +65,7 @@ namespace Nakama
         /// </summary>
         /// <param name="uri">The URI of the server.</param>
         /// <param name="timeout">The timeout for the connect attempt on the socket.</param>
-        void Connect(Uri uri, int timeout);
+        Task Connect(Uri uri, int timeout);
 
         /// <summary>
         /// Send data to the server with an asynchronous operation.
@@ -72,6 +73,6 @@ namespace Nakama
         /// <param name="buffer">The buffer with the message to send.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate when the operation should be canceled.</param>
         /// <param name="reliable">If the message should be sent reliably (will be ignored by some protocols).</param>
-        void Send(ArraySegment<byte> buffer, CancellationToken cancellationToken, bool reliable = true);
+        Task Send(ArraySegment<byte> buffer, CancellationToken cancellationToken, bool reliable = true);
     }
 }

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -163,7 +163,6 @@ namespace Nakama
                 {
                     lock (_lockObj)
                     {
-
                         foreach (var response in _responses)
                         {
                             response.Value.TrySetCanceled();
@@ -773,12 +772,12 @@ namespace Nakama
         private void ReceivedMessage(ArraySegment<byte> buffer)
         {
             var contents = System.Text.Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
-
             Logger?.DebugFormat("Received JSON over web socket: {0}", contents);
 
-            var envelope = contents.FromJson<WebSocketMessageEnvelope>();
             try
             {
+                var envelope = contents.FromJson<WebSocketMessageEnvelope>();
+
                 if (!string.IsNullOrEmpty(envelope.Cid))
                 {
                     lock (_lockObj)

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -237,18 +237,17 @@ namespace Nakama
         }
 
         /// <inheritdoc cref="CloseAsync"/>
-        public Task CloseAsync()
+        public async Task CloseAsync()
         {
-            if (!IsConnected && !IsConnecting)
+            if (IsConnected || IsConnecting)
             {
-                _adapter.Close();
+                await _adapter.Close();
+                IsConnected = false;
             }
             else
             {
                 Logger?.WarnFormat("Tried closing an already-closed socket");
             }
-
-            return Task.CompletedTask;
         }
 
         /// <inheritdoc cref="ConnectAsync"/>

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -234,7 +234,15 @@ namespace Nakama
         /// <inheritdoc cref="CloseAsync"/>
         public Task CloseAsync()
         {
-            _adapter.Close();
+            if (!IsConnected && !IsConnecting)
+            {
+                _adapter.Close();
+            }
+            else
+            {
+                Logger?.WarnFormat("Tried closing an already-closed socket");
+            }
+
             return Task.CompletedTask;
         }
 

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -924,6 +924,7 @@ namespace Nakama
             });
 
             await _adapter.Send(new ArraySegment<byte>(buffer), timeoutToken);
+
             return await completer.Task;
         }
 

--- a/src/Nakama/Socket.cs
+++ b/src/Nakama/Socket.cs
@@ -889,8 +889,7 @@ namespace Nakama
         {
             if (!IsConnected)
             {
-                Logger?.WarnFormat("Tried sending message on a socket that is not connected.");
-                return null;
+                throw new WebSocketException(WebSocketError.InvalidState, "Tried sending message on a socket that is not connected.");
             }
 
             var json = envelope.ToJson();

--- a/src/Nakama/WebSocketAdapter.cs
+++ b/src/Nakama/WebSocketAdapter.cs
@@ -141,7 +141,6 @@ namespace Nakama
                         webSocket.SendAsync(sendOperation.Bytes, WebSocketMessageType.Text, true, sendOperation.CancelSendToken);
                     }
 
-                    // todo what if the last param goes negative
                     var bufferSegment = new ArraySegment<byte>(buffer, bufferReadCount, MaxMessageReadSize - bufferReadCount);
 
                     if (receiveTask == null)

--- a/src/Nakama/WebSocketAdapter.cs
+++ b/src/Nakama/WebSocketAdapter.cs
@@ -58,6 +58,7 @@ namespace Nakama
                 NoDelay = true
             }, sendTimeoutSec)
         {
+
         }
 
         public WebSocketAdapter(WebSocketClientOptions options, int sendTimeoutSec)

--- a/src/Nakama/WebSocketAdapter.cs
+++ b/src/Nakama/WebSocketAdapter.cs
@@ -166,6 +166,7 @@ namespace Nakama
 
                         if (result == null || result.MessageType == WebSocketMessageType.Close)
                         {
+                            receiveTask = null;
                             break;
                         }
 

--- a/src/Nakama/WebSocketAdapter.cs
+++ b/src/Nakama/WebSocketAdapter.cs
@@ -89,7 +89,7 @@ namespace Nakama
         }
 
         /// <inheritdoc cref="ISocketAdapter.Connect"/>
-        public async void Connect(Uri uri, int timeout)
+        public async Task Connect(Uri uri, int timeout)
         {
             if (_webSocket != null)
             {
@@ -140,7 +140,7 @@ namespace Nakama
         }
 
         /// <inheritdoc cref="ISocketAdapter.Send"/>
-        public async void Send(ArraySegment<byte> buffer, CancellationToken cancellationToken,
+        public async Task Send(ArraySegment<byte> buffer, CancellationToken cancellationToken,
             bool reliable = true)
         {
             if (_webSocket == null)

--- a/tests/Nakama.Tests/AwaitedSocketTaskTest.cs
+++ b/tests/Nakama.Tests/AwaitedSocketTaskTest.cs
@@ -33,7 +33,6 @@ namespace Nakama.Tests
 
         public void Dispose()
         {
-            _socket.Dispose();
             _client = null;
         }
 

--- a/tests/Nakama.Tests/AwaitedSocketTaskTest.cs
+++ b/tests/Nakama.Tests/AwaitedSocketTaskTest.cs
@@ -51,7 +51,7 @@ namespace Nakama.Tests
         }
 
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
-        public async void Socket_AwaitedTasksAfterDisconnect_AreCanceled()
+        public async void Socket_AwaitedTasksAfterDisconnect_AreSilent()
         {
             var id = Guid.NewGuid().ToString();
             var session = await _client.AuthenticateCustomAsync(id);
@@ -60,8 +60,7 @@ namespace Nakama.Tests
             await _socket.CloseAsync();
             var statusTask1 = _socket.FollowUsersAsync(new[] {session.UserId});
             var statusTask2 = _socket.FollowUsersAsync(new[] {session.UserId});
-
-            await Assert.ThrowsAsync<TaskCanceledException>(() => Task.WhenAll(statusTask1, statusTask2));
+            await Task.WhenAll(statusTask1, statusTask2);
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
@@ -31,7 +31,7 @@ namespace Nakama.Tests.Socket
         {
             _client = TestsUtil.FromSettingsFile();
             _socket = Nakama.Socket.From(_client);
-            _socket.ReceivedError += (e) => throw e;
+            _socket.ReceivedError += e => System.Console.WriteLine(e.Message);
         }
 
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]

--- a/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketChannelTest.cs
@@ -31,6 +31,7 @@ namespace Nakama.Tests.Socket
         {
             _client = TestsUtil.FromSettingsFile();
             _socket = Nakama.Socket.From(_client);
+            _socket.ReceivedError += (e) => throw e;
         }
 
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]

--- a/tests/Nakama.Tests/Socket/WebSocketTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketTest.cs
@@ -56,7 +56,7 @@ namespace Nakama.Tests.Socket
         }
 
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
-        public async Task ShouldCreateSocketAndDisconnect()
+        public async Task ShouldCreateSocketAndDisconnectWithEvent()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
             var completer = new TaskCompletionSource<bool>();

--- a/tests/Nakama.Tests/Socket/WebSocketTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketTest.cs
@@ -81,12 +81,12 @@ namespace Nakama.Tests.Socket
         }
 
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
-        public async Task MultipleConnectAttemptsThrowException()
+        public async Task MultipleConnectAttemptsDoNotThrowException()
         {
             var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
             await _socket.ConnectAsync(session);
             Assert.True(_socket.IsConnected);
-            await Assert.ThrowsAsync<SocketException>(() => _socket.ConnectAsync(session));
+            await _socket.ConnectAsync(session);
         }
     }
 }

--- a/tests/Nakama.Tests/Socket/WebSocketTest.cs
+++ b/tests/Nakama.Tests/Socket/WebSocketTest.cs
@@ -32,6 +32,8 @@ namespace Nakama.Tests.Socket
         {
             _client = TestsUtil.FromSettingsFile();
             _socket = Nakama.Socket.From(_client);
+            var logger = new StdoutLogger();
+            _socket.ReceivedError += e => logger.ErrorFormat(e.Message);
         }
 
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]

--- a/tests/Nakama.Tests/StdoutLogger.cs
+++ b/tests/Nakama.Tests/StdoutLogger.cs
@@ -25,7 +25,7 @@ namespace Nakama.Tests
 
         public void ErrorFormat(string format, params object[] args)
         {
-            System.Console.WriteLine(string.Concat("[ERROR] ", format), args);
+            System.Console.Error.WriteLine(string.Concat("[ERROR] ", format), args);
         }
 
         public void InfoFormat(string format, params object[] args)

--- a/tests/Nakama.Tests/settings.json
+++ b/tests/Nakama.Tests/settings.json
@@ -3,5 +3,5 @@
   "PORT": 7350,
   "SCHEME": "http",
   "SERVER_KEY": "defaultkey",
-  "STDOUT": true
+  "STDOUT": false
 }

--- a/tests/Nakama.Tests/settings.json
+++ b/tests/Nakama.Tests/settings.json
@@ -3,5 +3,5 @@
   "PORT": 7350,
   "SCHEME": "http",
   "SERVER_KEY": "defaultkey",
-  "STDOUT": false
+  "STDOUT": true
 }


### PR DESCRIPTION
- The `Send` and `Connect` and `Close` methods of the adapter now return a `Task` so that exceptions may be properly caught by users.
- Moved `IsConnected` and `IsConnecting` bools to the `Socket` from the adapter since we now can use continuations to set this without knowledge of the adapter internals. Removed the `Connected` event and `SendTimeout` from the adapter for the same reason -- we can do this at at the level of the Socket because it can use continuations and cancel tokens now.
- If a user tries to connect while the socket is already connected, we now return early and log a warning rather than throwing an exception.
- Removed the `IsConnected` check done while dispatching `ReceivedError` (https://github.com/heroiclabs/nakama-dotnet/compare/luke/adapter-refactor?expand=1#diff-66d5e775e1fa826cbc2c6f8fd27e82897db168b20b2b32fea4434d4fd272e038L158) because we are now guaranteed to still be connected while this event is dispatching.
- Removed the catching of `ObjectDisposed` exception because we are now more deterministic with how we close and dispose of the socket in the case of an error or normal termination.  https://github.com/heroiclabs/nakama-dotnet/compare/luke/adapter-refactor?expand=1#diff-31781e450494b8d6a7059d1a9dcee82a1c15d42e06e59b0380118327348855b0L122
- The same logic of improved disposal determinism from within the adapter itself made me remove the `Dispose` method from the adapter's interface.
- Removed explicit checking of incoming frame sizes that are too large from the adapter. Ninja Websockets does this itself. Confirmed with test. It's done here: https://github.com/heroiclabs/nakama-dotnet/blob/master/src/Nakama/Ninja.WebSockets/Internal/WebSocketImplementation.cs#L126
- Simplified receive buffer logic.
