### PR TITLE
Update retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Requests can be supplied with a retry configurations in cases of transient netwo
 A single configuration can be used to control all request retry behavior:
 
 ```csharp
-var retryConfiguration = new RetryConfiguration(baseDelay: 1, maxRetries: 5, delegate { System.Console.Writeline("about to retry."); });
+var retryConfiguration = new RetryConfiguration(baseDelayMs: 1000, maxRetries: 5, delegate { System.Console.Writeline("about to retry."); });
 
 client.GlobalRetryConfiguration = retryConfiguration;
 var account = await client.GetAccountAsync(session);
@@ -107,7 +107,7 @@ Or, the configuration can be supplied on a per-request basis:
 
 ```csharp
 
-var retryConfiguration = new RetryConfiguration(baseDelay: 1, maxRetries: 5, delegate { System.Console.Writeline("about to retry."); });
+var retryConfiguration = new RetryConfiguration(baseDelayMs: 1000, maxRetries: 5, delegate { System.Console.Writeline("about to retry."); });
 
 var account = await client.GetAccountAsync(session, retryConfiguration);
 

--- a/src/Nakama/Client.cs
+++ b/src/Nakama/Client.cs
@@ -47,7 +47,7 @@ namespace Nakama
 
         /// <inheritdoc cref="IClient.GlobalRetryConfiguration"/>
         public RetryConfiguration GlobalRetryConfiguration { get; set; } = new RetryConfiguration(
-            baseDelay: 500,
+            baseDelayMs: 500,
             jitter: RetryJitter.FullJitter,
             listener: null,
             maxRetries: 4);

--- a/src/Nakama/Client.cs
+++ b/src/Nakama/Client.cs
@@ -89,7 +89,7 @@ namespace Nakama
 
         private readonly ApiClient _apiClient;
         private ILogger _logger;
-        private readonly RetryInvoker _retryInvoker = new RetryInvoker();
+        private readonly RetryInvoker _retryInvoker;
 
         private const int DefaultTimeout = 15;
 
@@ -117,6 +117,8 @@ namespace Nakama
             ServerKey = serverKey;
             _apiClient = new ApiClient(new UriBuilder(scheme, host, port).Uri, adapter, DefaultTimeout);
             Logger = NullLogger.Instance; // must set logger last.
+
+            _retryInvoker = new RetryInvoker(0, adapter.TransientExceptionDelegate);
         }
 
         /// <inheritdoc cref="AddFriendsAsync"/>

--- a/src/Nakama/HttpRequestAdapter.cs
+++ b/src/Nakama/HttpRequestAdapter.cs
@@ -135,7 +135,7 @@ namespace Nakama
 
         private bool IsTransientException(Exception e)
         {
-            return (e is ApiResponseException apiException && apiException.StatusCode >= 500) || e is HttpRequestException;
+            return (e is ApiResponseException apiException && (apiException.StatusCode >= 500 || apiException.StatusCode == -1)) || e is HttpRequestException;
         }
     }
 }

--- a/src/Nakama/HttpRequestAdapter.cs
+++ b/src/Nakama/HttpRequestAdapter.cs
@@ -36,6 +36,9 @@ namespace Nakama
         /// <inheritdoc cref="IHttpAdapter.Logger"/>
         public ILogger Logger { get; set; }
 
+        //
+        public TransientExceptionDelegate TransientExceptionDelegate => IsTransientException;
+
         private readonly HttpClient _httpClient;
 
         public HttpRequestAdapter(HttpClient httpClient)
@@ -128,6 +131,11 @@ namespace Nakama
             var client =
                 new HttpClient(compression ? (HttpMessageHandler) new GZipHttpClientHandler(handler) : handler);
             return new HttpRequestAdapter(client);
+        }
+
+        private bool IsTransientException(Exception e)
+        {
+            return (e is ApiResponseException apiException && apiException.StatusCode >= 500) || e is HttpRequestException;
         }
     }
 }

--- a/src/Nakama/IHttpAdapter.cs
+++ b/src/Nakama/IHttpAdapter.cs
@@ -26,6 +26,10 @@ namespace Nakama
     /// </summary>
     public interface IHttpAdapter
     {
+        // A delegate used by the adapter to determine whether or not an error from the server
+        // should be retried or not (i.e., is 'transient').
+        TransientExceptionDelegate TransientExceptionDelegate { get; }
+
         /// <summary>
         /// The logger to use with the adapter.
         /// </summary>

--- a/src/Nakama/RetryConfiguration.cs
+++ b/src/Nakama/RetryConfiguration.cs
@@ -32,7 +32,7 @@ namespace Nakama
         /// The base delay (milliseconds) used to calculate the time before making another request attempt.
         /// This base will be raised to N, where N is the number of retry attempts.
         /// </summary>
-        public int BaseDelay { get; }
+        public int BaseDelayMs { get; }
 
         /// <summary>
         /// The jitter algorithm used to apply randomness to the retry delay. Defaults to <see cref="RetryJitter.FullJitter"/>
@@ -52,30 +52,30 @@ namespace Nakama
         /// <summary>
         /// Create a new retry configuration.
         /// </summary>
-        /// <param name="baseDelay">The base delay (milliseconds) used to calculate the time before making another request attempt.</param>
+        /// <param name="baseDelayMs">The base delay (milliseconds) used to calculate the time before making another request attempt.</param>
         /// <param name="maxRetries">The maximum number of attempts to make before cancelling the request task.</param>
-        public RetryConfiguration(int baseDelay, int maxRetries) :
-            this(baseDelay, maxRetries, null, RetryJitter.FullJitter) {}
+        public RetryConfiguration(int baseDelayMs, int maxRetries) :
+            this(baseDelayMs, maxRetries, null, RetryJitter.FullJitter) {}
 
         /// <summary>
         /// Create a new retry configuration.
         /// </summary>
-        /// <param name="baseDelay">The base delay (milliseconds) used to calculate the time before making another request attempt.</param>
+        /// <param name="baseDelayMs">The base delay (milliseconds) used to calculate the time before making another request attempt.</param>
         /// <param name="maxRetries">The maximum number of attempts to make before cancelling the request task.</param>
         /// <param name="listener">A callback that is invoked before a new retry attempt is made.</param>
-        public RetryConfiguration(int baseDelay, int maxRetries, RetryListener listener) :
-            this(baseDelay, maxRetries, listener, RetryJitter.FullJitter) {}
+        public RetryConfiguration(int baseDelayMs, int maxRetries, RetryListener listener) :
+            this(baseDelayMs, maxRetries, listener, RetryJitter.FullJitter) {}
 
         /// <summary>
         /// Create a new retry configuration.
         /// </summary>
-        /// <param name="baseDelay">The base delay (milliseconds) used to calculate the time before making another request attempt.</param>
+        /// <param name="baseDelayMs">The base delay (milliseconds) used to calculate the time before making another request attempt.</param>
         /// <param name="maxRetries">The maximum number of attempts to make before cancelling the request task.</param>
         /// <param name="listener">A callback that is invoked before a new retry attempt is made.</param>
         /// <param name="jitter">/// The jitter algorithm used to apply randomness to the retry delay.</param>
-        public RetryConfiguration(int baseDelay, int maxRetries, RetryListener listener, Jitter jitter)
+        public RetryConfiguration(int baseDelayMs, int maxRetries, RetryListener listener, Jitter jitter)
         {
-            BaseDelay = baseDelay;
+            BaseDelayMs = baseDelayMs;
             RetryListener = listener;
             MaxAttempts = maxRetries;
             Jitter = jitter;

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -83,7 +83,7 @@ namespace Nakama
 
         private Retry CreateNewRetry(RetryHistory history)
         {
-            int expoBackoff = System.Convert.ToInt32(Math.Pow(history.Configuration.BaseDelay, history.Retries.Count + 1));
+            int expoBackoff = System.Convert.ToInt32(Math.Pow(history.Configuration.BaseDelayMs, history.Retries.Count + 1));
             int jitteredBackoff = history.Configuration.Jitter(history.Retries, expoBackoff, new Random(JitterSeed));
             return new Retry(expoBackoff, jitteredBackoff);
         }

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -21,15 +21,30 @@ using System.Threading.Tasks;
 namespace Nakama
 {
     /// <summary>
+    /// A delegate used by the retry invoker to determine whether or not an exception from the server is
+    /// considered "transient" from the client. For example, timeouts can be transient in cases where
+    /// the server is experiencing temporarily high load.
+    /// </summary>
+    public delegate bool TransientExceptionDelegate(Exception e);
+
+    /// <summary>
     /// Invokes requests with retry and exponential backoff.
     /// </summary>
     internal class RetryInvoker
     {
         public int JitterSeed { get; private set; }
+        private readonly TransientExceptionDelegate _del;
 
-        public RetryInvoker(int jitterSeed = 0)
+        public RetryInvoker(int jitterSeed, TransientExceptionDelegate del)
         {
             JitterSeed = jitterSeed;
+
+            if (del == null)
+            {
+                throw new ArgumentException("Cannot initialize retry invoker with a null transient exception delegate.");
+            }
+
+            _del = del;
         }
 
         public async Task<T> InvokeWithRetry<T>(Func<Task<T>> request, RetryHistory history)
@@ -40,7 +55,7 @@ namespace Nakama
             }
             catch (Exception e)
             {
-                if (history.Configuration != null && IsTransientException(e))
+                if (history.Configuration != null && _del(e))
                 {
                     await Backoff(history, e);
                     return await InvokeWithRetry<T>(request, history);
@@ -60,7 +75,7 @@ namespace Nakama
             }
             catch (Exception e)
             {
-                if (history.Configuration != null && IsTransientException(e))
+                if (history.Configuration != null && _del(e))
                 {
                     await Backoff(history, e);
                     await InvokeWithRetry(request, history);
@@ -70,15 +85,6 @@ namespace Nakama
                     throw e;
                 }
             }
-        }
-
-        /// <summary>
-        /// Whether or not the provided exception represents a temporary erroroneous state in the connection
-        /// or on the server.
-        /// </summary>
-        private bool IsTransientException(Exception e)
-        {
-            return (e is ApiResponseException apiException && apiException.StatusCode >= 500) || e is HttpRequestException;
         }
 
         private Retry CreateNewRetry(RetryHistory history)

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -83,7 +83,7 @@ namespace Nakama
 
         private Retry CreateNewRetry(RetryHistory history)
         {
-            int expoBackoff = System.Convert.ToInt32(Math.Pow(history.Configuration.BaseDelayMs, history.Retries.Count + 1));
+            int expoBackoff = System.Convert.ToInt32(Math.Pow(2, history.Retries.Count + 1)) * history.Configuration.BaseDelayMs;
             int jitteredBackoff = history.Configuration.Jitter(history.Retries, expoBackoff, new Random(JitterSeed));
             return new Retry(expoBackoff, jitteredBackoff);
         }

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -89,7 +89,7 @@ namespace Nakama
 
         private Retry CreateNewRetry(RetryHistory history)
         {
-            int expoBackoff = System.Convert.ToInt32(Math.Pow(2, history.Retries.Count + 1)) * history.Configuration.BaseDelayMs;
+            int expoBackoff = System.Convert.ToInt32(Math.Pow(2, history.Retries.Count)) * history.Configuration.BaseDelayMs;
             int jitteredBackoff = history.Configuration.Jitter(history.Retries, expoBackoff, new Random(JitterSeed));
             return new Retry(expoBackoff, jitteredBackoff);
         }

--- a/src/Nakama/RetryInvoker.cs
+++ b/src/Nakama/RetryInvoker.cs
@@ -40,7 +40,7 @@ namespace Nakama
             }
             catch (Exception e)
             {
-                if (IsTransientException(e))
+                if (history.Configuration != null && IsTransientException(e))
                 {
                     await Backoff(history, e);
                     return await InvokeWithRetry<T>(request, history);
@@ -60,7 +60,7 @@ namespace Nakama
             }
             catch (Exception e)
             {
-                if (IsTransientException(e))
+                if (history.Configuration != null && IsTransientException(e))
                 {
                     await Backoff(history, e);
                     await InvokeWithRetry(request, history);

--- a/tests/Nakama.Tests/AuthenticateTest.cs
+++ b/tests/Nakama.Tests/AuthenticateTest.cs
@@ -60,6 +60,21 @@ namespace Nakama.Tests.Api
             Assert.Equal(1, account.Devices.Count(d => d.Id == deviceid));
         }
 
+
+        [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
+        public async Task ShouldAuthenticateDeviceAndSaveUsername()
+        {
+            var deviceid = Guid.NewGuid().ToString();
+            var username = Guid.NewGuid().ToString();
+            var session = await _client.AuthenticateDeviceAsync(deviceid, username);
+
+
+            var account = await _client.GetAccountAsync(session);
+
+            Assert.Equal(username, session.Username);
+            Assert.Equal(username, account.User.Username);
+        }
+
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
         public async Task ShouldAuthenticateEmail()
         {

--- a/tests/Nakama.Tests/RetryTest.cs
+++ b/tests/Nakama.Tests/RetryTest.cs
@@ -240,5 +240,22 @@ namespace Nakama.Tests
             // actual will be slightly higher due to cpu elapsed time
             Assert.True(expectedElapsedTime < actualElapsedTime);
         }
+
+        [Fact]
+        public async void RetryConfiguration_NullConfiguration_DoesNotThrowNullRef()
+        {
+            var adapterSchedule = new TransientAdapterResponseType[3] {
+                TransientAdapterResponseType.TransientError,
+                TransientAdapterResponseType.TransientError,
+                TransientAdapterResponseType.TransientError,
+            };
+
+            var adapter = new TransientExceptionHttpAdapter(adapterSchedule);
+            var client = TestsUtil.FromSettingsFile(TestsUtil.DefaultSettingsPath, adapter);
+
+            client.GlobalRetryConfiguration = null;
+
+            await Assert.ThrowsAsync<ApiResponseException>(async () => await client.AuthenticateCustomAsync("test_id"));
+        }
     }
 }

--- a/tests/Nakama.Tests/RetryTest.cs
+++ b/tests/Nakama.Tests/RetryTest.cs
@@ -286,5 +286,20 @@ namespace Nakama.Tests
                 throw e;
             }
         }
+
+        [Fact]
+        public async void RetryConfiguration_NonTransientError_Throws()
+        {
+            var adapterSchedule = new TransientAdapterResponseType[1] {
+                TransientAdapterResponseType.NonTransientError,
+            };
+
+            var adapter = new TransientExceptionHttpAdapter(adapterSchedule);
+            var client = TestsUtil.FromSettingsFile(TestsUtil.DefaultSettingsPath, adapter);
+
+            client.GlobalRetryConfiguration = new RetryConfiguration(baseDelay: 1, maxRetries: 3);
+
+            ApiResponseException e = await Assert.ThrowsAsync<ApiResponseException>(async () => await client.AuthenticateCustomAsync("test_id"));
+        }
     }
 }

--- a/tests/Nakama.Tests/RetryTest.cs
+++ b/tests/Nakama.Tests/RetryTest.cs
@@ -197,8 +197,8 @@ namespace Nakama.Tests
             Assert.NotNull(session);
 
             Assert.Equal(10, retries[0].ExponentialBackoff);
-            Assert.Equal(100, retries[1].ExponentialBackoff);
-            Assert.Equal(1000, retries[2].ExponentialBackoff);
+            Assert.Equal(20, retries[1].ExponentialBackoff);
+            Assert.Equal(40, retries[2].ExponentialBackoff);
         }
 
         [Fact]

--- a/tests/Nakama.Tests/RetryTest.cs
+++ b/tests/Nakama.Tests/RetryTest.cs
@@ -49,7 +49,7 @@ namespace Nakama.Tests
                 lastNumRetry = numRetry;
             };
 
-            var config = new RetryConfiguration(baseDelay: 10, maxRetries: 1, retryListener);
+            var config = new RetryConfiguration(baseDelayMs: 10, maxRetries: 1, retryListener);
             client.GlobalRetryConfiguration = config;
 
             ISession session = await client.AuthenticateCustomAsync("test_id");
@@ -79,7 +79,7 @@ namespace Nakama.Tests
                 lastNumRetry = numRetry;
             };
 
-            var config = new RetryConfiguration(baseDelay: 1, maxRetries: 5, retryListener);
+            var config = new RetryConfiguration(baseDelayMs: 1, maxRetries: 5, retryListener);
             client.GlobalRetryConfiguration = config;
 
             Task<ISession> sessionTask = client.AuthenticateCustomAsync("test_id");
@@ -131,7 +131,7 @@ namespace Nakama.Tests
                 lastNumRetry = numRetry;
             };
 
-            var config = new RetryConfiguration(baseDelay: 10, maxRetries: 0, retryListener);
+            var config = new RetryConfiguration(baseDelayMs: 10, maxRetries: 0, retryListener);
             client.GlobalRetryConfiguration = config;
 
             Task<ISession> sessionTask = client.AuthenticateCustomAsync("test_id");
@@ -159,10 +159,10 @@ namespace Nakama.Tests
                 lastNumRetry = numRetry;
             };
 
-            var globalConfig = new RetryConfiguration(baseDelay: 10, maxRetries: 1, retryListener);
+            var globalConfig = new RetryConfiguration(baseDelayMs: 10, maxRetries: 1, retryListener);
             client.GlobalRetryConfiguration = globalConfig;
 
-            var localConfig = new RetryConfiguration(baseDelay: 10, maxRetries: 3, retryListener);
+            var localConfig = new RetryConfiguration(baseDelayMs: 10, maxRetries: 3, retryListener);
             var session = await client.AuthenticateCustomAsync("test_id", null, true, null, localConfig, null);
             Assert.NotNull(session);
             Assert.Equal(3, lastNumRetry);
@@ -189,7 +189,7 @@ namespace Nakama.Tests
                 retries.Add(retry);
             };
 
-            var config = new RetryConfiguration(baseDelay: 10, maxRetries: 3, retryListener);
+            var config = new RetryConfiguration(baseDelayMs: 10, maxRetries: 3, retryListener);
             client.GlobalRetryConfiguration = config;
 
             Task<ISession> sessionTask = client.AuthenticateCustomAsync("test_id");
@@ -219,7 +219,7 @@ namespace Nakama.Tests
                 retries.Add(retry);
             };
 
-            var config = new RetryConfiguration(baseDelay: 10, maxRetries: 3, retryListener);
+            var config = new RetryConfiguration(baseDelayMs: 10, maxRetries: 3, retryListener);
             client.GlobalRetryConfiguration = config;
 
             DateTime timeBeforeRequest = DateTime.Now;
@@ -270,7 +270,7 @@ namespace Nakama.Tests
             var adapter = new TransientExceptionHttpAdapter(adapterSchedule);
             var client = TestsUtil.FromSettingsFile(TestsUtil.DefaultSettingsPath, adapter);
 
-            client.GlobalRetryConfiguration = new RetryConfiguration(baseDelay: 1, maxRetries: 0);
+            client.GlobalRetryConfiguration = new RetryConfiguration(baseDelayMs: 1, maxRetries: 0);
 
             try
             {
@@ -297,7 +297,7 @@ namespace Nakama.Tests
             var adapter = new TransientExceptionHttpAdapter(adapterSchedule);
             var client = TestsUtil.FromSettingsFile(TestsUtil.DefaultSettingsPath, adapter);
 
-            client.GlobalRetryConfiguration = new RetryConfiguration(baseDelay: 1, maxRetries: 3);
+            client.GlobalRetryConfiguration = new RetryConfiguration(baseDelayMs: 1, maxRetries: 3);
 
             ApiResponseException e = await Assert.ThrowsAsync<ApiResponseException>(async () => await client.AuthenticateCustomAsync("test_id"));
         }

--- a/tests/Nakama.Tests/RetryTest.cs
+++ b/tests/Nakama.Tests/RetryTest.cs
@@ -107,9 +107,8 @@ namespace Nakama.Tests
                 lastNumRetry = numRetry;
             };
 
-            var config = new RetryConfiguration(baseDelay: 10, maxRetries: 3, retryListener);
+            var config = new RetryConfiguration(baseDelayMs: 500, maxRetries: 3, retryListener);
             client.GlobalRetryConfiguration = config;
-
 
             Task<ISession> sessionTask = client.AuthenticateCustomAsync("test_id");
 

--- a/tests/Nakama.Tests/TransientExceptionHttpAdapter.cs
+++ b/tests/Nakama.Tests/TransientExceptionHttpAdapter.cs
@@ -35,7 +35,7 @@ namespace Nakama.Tests
     {
         public ILogger Logger { get; set; }
 
-        public TransientExceptionDelegate TransientExceptionDelegate => throw new NotImplementedException();
+        public TransientExceptionDelegate TransientExceptionDelegate => IsTransientException;
 
         private int _sendAttempts = 0;
         private readonly TransientAdapterResponseType[] _sendSchedule;

--- a/tests/Nakama.Tests/TransientExceptionHttpAdapter.cs
+++ b/tests/Nakama.Tests/TransientExceptionHttpAdapter.cs
@@ -24,7 +24,8 @@ namespace Nakama.Tests
     public enum TransientAdapterResponseType
     {
         ServerOk,
-        TransientError
+        TransientError,
+        NonTransientError
     }
 
     /// <summary>
@@ -57,6 +58,8 @@ namespace Nakama.Tests
             {
                 case TransientAdapterResponseType.TransientError:
                     throw new ApiResponseException(500, "This exception represents a transient error.", -1);
+                case TransientAdapterResponseType.NonTransientError:
+                    throw new ApiResponseException(401, "This exception represents a non-transient error.", -1);
                 default:
                     return _httpRequestAdapter.SendAsync(method, uri, headers, body, timeoutSec);
             }

--- a/tests/Nakama.Tests/TransientExceptionHttpAdapter.cs
+++ b/tests/Nakama.Tests/TransientExceptionHttpAdapter.cs
@@ -35,6 +35,8 @@ namespace Nakama.Tests
     {
         public ILogger Logger { get; set; }
 
+        public TransientExceptionDelegate TransientExceptionDelegate => throw new NotImplementedException();
+
         private int _sendAttempts = 0;
         private readonly TransientAdapterResponseType[] _sendSchedule;
         private readonly IHttpAdapter _httpRequestAdapter = HttpRequestAdapter.WithGzip();
@@ -63,6 +65,11 @@ namespace Nakama.Tests
                 default:
                     return _httpRequestAdapter.SendAsync(method, uri, headers, body, timeoutSec);
             }
+        }
+
+        private bool IsTransientException(Exception e)
+        {
+            return (e is ApiResponseException apiException && apiException.StatusCode >= 500);
         }
     }
 }


### PR DESCRIPTION
- Move `IsTransientException` checks to each HTTP adapter so it can check for the specific exception types it surfaces. - Fix backoff algorithm.
- Confirm that retry logic doesn't stomp any original network exceptions with a `TaskCancelledException` since the original exception can be obtained via `GetBaseException.`
- Retry if client cannot reach load balancer.
- [ ] Change readme to catch `TaskCancelledException` instead of `ApiResponseException`, or just unwrap the base exception in the retry invoker to preserve backwards compatibility.