### PR TITLE
Prevent UnobservedTaskException logs in socket receive loop.

### DIFF
--- a/Nakama/WebsocketStdlibAdapter.cs
+++ b/Nakama/WebsocketStdlibAdapter.cs
@@ -184,6 +184,10 @@ namespace Nakama
                     bufferReadCount = 0;
                 } while (_webSocket.State == WebSocketState.Open && !canceller.IsCancellationRequested);
             }
+            catch (Exception e)
+            {
+                ReceivedError?.Invoke(e);
+            }
             finally
             {
                 Closed?.Invoke();

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -6,14 +6,14 @@ codegen
 ## Usage
 
 ```shell
-go run main.go "$GOPATH/src/github.com/heroiclabs/nakama/apigrpc/apigrpc.swagger.json" > ../src/Nakama/ApiClient.gen.cs
+go run main.go "$GOPATH/src/github.com/heroiclabs/nakama/apigrpc/apigrpc.swagger.json" > ../Nakama/ApiClient.gen.cs
 ```
 
 ### Console API
 
 To generate a client for the Nakama Console, run the following:
 ```shell
-go run main.go "$GOPATH/src/github.com/heroiclabs/nakama/console/console.swagger.json" "Console" > ../src/Nakama/ConsoleClient.gen.cs
+go run main.go "$GOPATH/src/github.com/heroiclabs/nakama/console/console.swagger.json" "Console" > ../Nakama/Console/ConsoleClient.gen.cs
 ```
 
 ### Rationale

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -871,7 +871,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../src/Nakama/ ../README.md ../CHANGELOG.md
+INPUT                  = ../Nakama/ ../README.md ../CHANGELOG.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Some game studios attach an event handler to listen to `TaskScheduler.UnobservedTaskException`:

https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskscheduler.unobservedtaskexception?view=net-6.0

This gets noisy with the SDK because we (purposefully) did not trap exceptions raised off the receive loop which aren't actionable. Now we raise them up so that they can be handled optionally and eliminates the noise raised by the `TaskScheduler`.