### PR TITLE
Socket multithreading fixes

### DIFF
--- a/Nakama/Socket.cs
+++ b/Nakama/Socket.cs
@@ -27,7 +27,7 @@ namespace Nakama
     /// </summary>
     public class Socket : ISocket
     {
-        private static int _cid; // callback id.
+        private int _cid; // callback id.
 
         /// <summary>
         /// The default timeout for when the socket connects.

--- a/Nakama/Socket.cs
+++ b/Nakama/Socket.cs
@@ -187,7 +187,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyAccept = new PartyAccept
                 {
                     PartyId = partyId,
@@ -195,6 +195,7 @@ namespace Nakama
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -204,7 +205,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 MatchmakerAdd = new MatchmakerAddMessage
                 {
                     Query = query,
@@ -214,6 +215,8 @@ namespace Nakama
                     NumericProperties = numericProperties
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.MatchmakerTicket;
         }
@@ -225,7 +228,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyMatchmakerAdd = new PartyMatchmakerAdd
                 {
                     PartyId = partyId,
@@ -237,6 +240,7 @@ namespace Nakama
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.PartyMatchmakerTicket;
         }
@@ -261,10 +265,11 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyClose = new PartyClose { PartyId = partyId }
             };
 
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -273,9 +278,11 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 MatchCreate = new MatchCreateMessage { Name = name }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Match;
         }
@@ -285,7 +292,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyCreate = new PartyCreate
                 {
                     Open = open,
@@ -293,6 +300,7 @@ namespace Nakama
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Party;
         }
@@ -306,13 +314,15 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 StatusFollow = new StatusFollowMessage
                 {
                     UserIds = new List<string>(userIDs),
                     Usernames = usernames != null ? new List<string>(usernames) : new List<string>()
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Status;
         }
@@ -323,7 +333,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 ChannelJoin = new ChannelJoinMessage
                 {
                     Hidden = hidden,
@@ -332,6 +342,8 @@ namespace Nakama
                     Type = (int)type
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Channel;
         }
@@ -351,9 +363,11 @@ namespace Nakama
 
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 MatchJoin = message
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Match;
         }
@@ -363,13 +377,15 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 MatchJoin = new MatchJoinMessage
                 {
                     MatchId = matchId,
                     Metadata = metadata
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Match;
         }
@@ -379,13 +395,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyJoin = new PartyJoin
                 {
                     PartyId = partyId
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -397,12 +414,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 ChannelLeave = new ChannelLeaveMessage
                 {
                     ChannelId = channelId
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -414,12 +433,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 MatchLeave = new MatchLeaveMessage
                 {
                     MatchId = matchId
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -428,13 +449,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyLeave = new PartyLeave
                 {
                     PartyId = partyId
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -443,13 +465,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyJoinRequestList = new PartyJoinRequestList
                 {
                     PartyId = partyId,
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.PartyJoinRequest;
         }
@@ -459,7 +482,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyPromote = new PartyPromote
                 {
                     PartyId = partyId,
@@ -467,6 +490,8 @@ namespace Nakama
                 }
             };
 
+
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -479,13 +504,15 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 ChannelMessageRemove = new ChannelRemoveMessage
                 {
                     ChannelId = channelId,
                     MessageId = messageId
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.ChannelMessageAck;
         }
@@ -498,13 +525,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 MatchmakerRemove = new MatchmakerRemoveMessage
                 {
                     Ticket = ticket
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -513,7 +541,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyMatchmakerRemove = new PartyMatchmakerRemove
                 {
                     PartyId = partyId,
@@ -521,6 +549,7 @@ namespace Nakama
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -529,7 +558,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 PartyMemberRemove = new PartyMemberRemove
                 {
                     PartyId = partyId,
@@ -537,6 +566,7 @@ namespace Nakama
                 }
             };
 
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -545,13 +575,15 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 Rpc = new ApiRpc
                 {
                     Id = funcId,
                     Payload = payload
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Rpc;
         }
@@ -561,13 +593,15 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 Rpc = new ApiRpc
                 {
                     Id = funcId,
                     Payload = Convert.ToBase64String(payload.Array, payload.Offset, payload.Count)
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Rpc;
         }
@@ -661,12 +695,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 StatusUnfollow = new StatusUnfollowMessage
                 {
                     UserIds = new List<string>(userIDs)
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -679,7 +715,7 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 ChannelMessageUpdate = new ChannelUpdateMessage
                 {
                     ChannelId = channelId,
@@ -687,6 +723,8 @@ namespace Nakama
                     Content = content
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.ChannelMessageAck;
         }
@@ -696,12 +734,14 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 StatusUpdate = new StatusUpdateMessage
                 {
                     Status = status
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -714,13 +754,15 @@ namespace Nakama
         {
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid++}",
+                Cid = $"{_cid}",
                 ChannelMessageSend = new ChannelSendMessage
                 {
                     ChannelId = channelId,
                     Content = content
                 }
             };
+
+            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.ChannelMessageAck;
         }

--- a/Nakama/Socket.cs
+++ b/Nakama/Socket.cs
@@ -185,9 +185,10 @@ namespace Nakama
         /// <inheritdoc cref="AcceptPartyMemberAsync"/>
         public Task AcceptPartyMemberAsync(string partyId, IUserPresence presence)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyAccept = new PartyAccept
                 {
                     PartyId = partyId,
@@ -195,7 +196,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -203,9 +203,10 @@ namespace Nakama
         public async Task<IMatchmakerTicket> AddMatchmakerAsync(string query = "*", int minCount = 2, int maxCount = 8,
             Dictionary<string, string> stringProperties = null, Dictionary<string, double> numericProperties = null)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 MatchmakerAdd = new MatchmakerAddMessage
                 {
                     Query = query,
@@ -216,7 +217,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.MatchmakerTicket;
         }
@@ -226,9 +226,10 @@ namespace Nakama
             int maxCount, Dictionary<string, string> stringProperties = null,
             Dictionary<string, double> numericProperties = null)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyMatchmakerAdd = new PartyMatchmakerAdd
                 {
                     PartyId = partyId,
@@ -240,7 +241,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.PartyMatchmakerTicket;
         }
@@ -263,26 +263,26 @@ namespace Nakama
         /// <inheritdoc cref="ClosePartyAsync"/>
         public Task ClosePartyAsync(string partyId)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyClose = new PartyClose { PartyId = partyId }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
         /// <inheritdoc cref="CreateMatchAsync"/>
         public async Task<IMatch> CreateMatchAsync(string name = null)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 MatchCreate = new MatchCreateMessage { Name = name }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Match;
         }
@@ -290,9 +290,10 @@ namespace Nakama
         /// <inheritdoc cref="CreatePartyAsync"/>
         public async Task<IParty> CreatePartyAsync(bool open, int maxSize)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyCreate = new PartyCreate
                 {
                     Open = open,
@@ -300,7 +301,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Party;
         }
@@ -312,9 +312,10 @@ namespace Nakama
         /// <inheritdoc cref="FollowUsersAsync(System.Collections.Generic.IEnumerable{string},System.Collections.Generic.IEnumerable{string})"/>
         public async Task<IStatus> FollowUsersAsync(IEnumerable<string> userIDs, IEnumerable<string> usernames = null)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 StatusFollow = new StatusFollowMessage
                 {
                     UserIds = new List<string>(userIDs),
@@ -322,7 +323,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Status;
         }
@@ -331,9 +331,10 @@ namespace Nakama
         public async Task<IChannel> JoinChatAsync(string target, ChannelType type, bool persistence = false,
             bool hidden = false)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 ChannelJoin = new ChannelJoinMessage
                 {
                     Hidden = hidden,
@@ -343,7 +344,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Channel;
         }
@@ -361,13 +361,13 @@ namespace Nakama
                 message.MatchId = matched.MatchId;
             }
 
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 MatchJoin = message
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Match;
         }
@@ -375,9 +375,11 @@ namespace Nakama
         /// <inheritdoc cref="JoinMatchAsync(string,IDictionary{string, string})"/>
         public async Task<IMatch> JoinMatchAsync(string matchId, IDictionary<string, string> metadata = null)
         {
+            int cid = Interlocked.Increment(ref _cid);
+
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 MatchJoin = new MatchJoinMessage
                 {
                     MatchId = matchId,
@@ -385,7 +387,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Match;
         }
@@ -393,16 +394,16 @@ namespace Nakama
         /// <inheritdoc cref="JoinPartyAsync"/>
         public Task JoinPartyAsync(string partyId)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyJoin = new PartyJoin
                 {
                     PartyId = partyId
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -412,16 +413,16 @@ namespace Nakama
         /// <inheritdoc cref="LeaveChatAsync(string)"/>
         public Task LeaveChatAsync(string channelId)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 ChannelLeave = new ChannelLeaveMessage
                 {
                     ChannelId = channelId
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -431,48 +432,48 @@ namespace Nakama
         /// <inheritdoc cref="LeaveMatchAsync(string)"/>
         public Task LeaveMatchAsync(string matchId)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 MatchLeave = new MatchLeaveMessage
                 {
                     MatchId = matchId
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
         /// <inheritdoc cref="LeavePartyAsync"/>
         public Task LeavePartyAsync(string partyId)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyLeave = new PartyLeave
                 {
                     PartyId = partyId
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
         /// <inheritdoc cref="ListPartyJoinRequestsAsync"/>
         public async Task<IPartyJoinRequest> ListPartyJoinRequestsAsync(string partyId)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyJoinRequestList = new PartyJoinRequestList
                 {
                     PartyId = partyId,
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.PartyJoinRequest;
         }
@@ -480,9 +481,10 @@ namespace Nakama
         /// <inheritdoc cref="PromotePartyMemberAsync"/>
         public Task PromotePartyMemberAsync(string partyId, IUserPresence partyMember)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyPromote = new PartyPromote
                 {
                     PartyId = partyId,
@@ -491,7 +493,6 @@ namespace Nakama
             };
 
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -502,9 +503,10 @@ namespace Nakama
         /// <inheritdoc cref="RemoveChatMessageAsync(string,string)"/>
         public async Task<IChannelMessageAck> RemoveChatMessageAsync(string channelId, string messageId)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 ChannelMessageRemove = new ChannelRemoveMessage
                 {
                     ChannelId = channelId,
@@ -512,7 +514,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.ChannelMessageAck;
         }
@@ -523,25 +524,26 @@ namespace Nakama
         /// <inheritdoc cref="RemoveMatchmakerAsync(string)"/>
         public Task RemoveMatchmakerAsync(string ticket)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 MatchmakerRemove = new MatchmakerRemoveMessage
                 {
                     Ticket = ticket
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
         /// <inheritdoc cref="RemoveMatchmakerPartyAsync"/>
         public Task RemoveMatchmakerPartyAsync(string partyId, string ticket)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyMatchmakerRemove = new PartyMatchmakerRemove
                 {
                     PartyId = partyId,
@@ -549,16 +551,16 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
         /// <inheritdoc cref="RemovePartyMemberAsync"/>
         public Task RemovePartyMemberAsync(string partyId, IUserPresence presence)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 PartyMemberRemove = new PartyMemberRemove
                 {
                     PartyId = partyId,
@@ -566,16 +568,16 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
         /// <inheritdoc cref="RpcAsync(string,string)"/>
         public async Task<IApiRpc> RpcAsync(string funcId, string payload = null)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 Rpc = new ApiRpc
                 {
                     Id = funcId,
@@ -583,7 +585,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Rpc;
         }
@@ -591,9 +592,10 @@ namespace Nakama
         /// <inheritdoc cref="RpcAsync(string,ArraySegment{byte})"/>
         public async Task<IApiRpc> RpcAsync(string funcId, ArraySegment<byte> payload)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 Rpc = new ApiRpc
                 {
                     Id = funcId,
@@ -601,7 +603,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.Rpc;
         }
@@ -693,16 +694,16 @@ namespace Nakama
         /// <inheritdoc cref="UnfollowUsersAsync(System.Collections.Generic.IEnumerable{string})"/>
         public Task UnfollowUsersAsync(IEnumerable<string> userIDs)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 StatusUnfollow = new StatusUnfollowMessage
                 {
                     UserIds = new List<string>(userIDs)
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -713,9 +714,10 @@ namespace Nakama
         /// <inheritdoc cref="UpdateChatMessageAsync(string,string,string)"/>
         public async Task<IChannelMessageAck> UpdateChatMessageAsync(string channelId, string messageId, string content)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 ChannelMessageUpdate = new ChannelUpdateMessage
                 {
                     ChannelId = channelId,
@@ -724,7 +726,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.ChannelMessageAck;
         }
@@ -732,16 +733,16 @@ namespace Nakama
         /// <inheritdoc cref="UpdateStatusAsync"/>
         public Task UpdateStatusAsync(string status)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 StatusUpdate = new StatusUpdateMessage
                 {
                     Status = status
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             return SendAsync(envelope);
         }
 
@@ -752,9 +753,10 @@ namespace Nakama
         /// <inheritdoc cref="WriteChatMessageAsync(string,string)"/>
         public async Task<IChannelMessageAck> WriteChatMessageAsync(string channelId, string content)
         {
+            int cid = Interlocked.Increment(ref _cid);
             var envelope = new WebSocketMessageEnvelope
             {
-                Cid = $"{_cid}",
+                Cid = $"{cid}",
                 ChannelMessageSend = new ChannelSendMessage
                 {
                     ChannelId = channelId,
@@ -762,7 +764,6 @@ namespace Nakama
                 }
             };
 
-            Interlocked.Increment(ref _cid);
             var response = await SendAsync(envelope);
             return response.ChannelMessageAck;
         }

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ dotnet build src/Nakama/Nakama.csproj
 For release builds use:
 
 ```shell
-dotnet build -c Release /p:AssemblyVersion=2.0.0.0 src/Nakama/Nakama.csproj
+dotnet build -c Release /p:AssemblyVersion=2.0.0.0 Nakama/Nakama.csproj
 // For Nuget packaging
-dotnet pack -p:AssemblyVersion=2.0.0.0 -p:PackageVersion=2.0.0 -c Release src/Nakama/Nakama.csproj
+dotnet pack -p:AssemblyVersion=2.0.0.0 -p:PackageVersion=2.0.0 -c Release Nakama/Nakama.csproj
 ```
 
 ### Run Tests


### PR DESCRIPTION
A few related issues:

(1) Move `cid` from a static to an instance variable to avoid sockets from multiple threads affecting one another's `cids`.
(2) Allow multiple threads to write to the same socket by atomically incrementing the instance cid member.
(3) If a socket send times out, remove the completer from our pending response collection. If the server winds up responding with a matching cid after the timeout, ignore the response.

TODO 
- [ ] test implications for unity webgl