### PR TITLE
seed retry jitter according to user-specific data

### DIFF
--- a/Nakama/IClient.cs
+++ b/Nakama/IClient.cs
@@ -45,11 +45,6 @@ namespace Nakama
         int Port { get; }
 
         /// <summary>
-        /// Used to seed random values generated during request retries.
-        /// </summary>
-        int RetryJitterSeed { get; }
-
-        /// <summary>
         /// The protocol scheme used to connect with the server. Must be either "http" or "https".
         /// </summary>
         string Scheme { get; }

--- a/Nakama/RetryHistory.cs
+++ b/Nakama/RetryHistory.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -24,12 +25,18 @@ namespace Nakama
         public RetryConfiguration Configuration { get; }
         public List<Retry> Retries { get; }
         public CancellationToken? UserCancelToken { get; }
+        public Random Random { get; }
 
-        public RetryHistory(RetryConfiguration configuration, CancellationToken? userCancelToken)
+        public RetryHistory(ISession session, RetryConfiguration configuration, CancellationToken? userCancelToken) : this(session.AuthToken, configuration, userCancelToken)
+        {
+        }
+
+        public RetryHistory(string jitterHashKey, RetryConfiguration configuration, CancellationToken? userCancelToken)
         {
             Configuration = configuration;
             Retries = new List<Retry>();
             UserCancelToken = userCancelToken;
+            Random = new Random(jitterHashKey.GetHashCode());
         }
     }
 }

--- a/Nakama/RetryInvoker.cs
+++ b/Nakama/RetryInvoker.cs
@@ -32,13 +32,10 @@ namespace Nakama
     /// </summary>
     internal class RetryInvoker
     {
-        public int JitterSeed { get; private set; }
         private readonly TransientExceptionDelegate _del;
 
-        public RetryInvoker(int jitterSeed, TransientExceptionDelegate del)
+        public RetryInvoker(TransientExceptionDelegate del)
         {
-            JitterSeed = jitterSeed;
-
             if (del == null)
             {
                 throw new ArgumentException("Cannot initialize retry invoker with a null transient exception delegate.");
@@ -90,7 +87,7 @@ namespace Nakama
         private Retry CreateNewRetry(RetryHistory history)
         {
             int expoBackoff = System.Convert.ToInt32(Math.Pow(2, history.Retries.Count)) * history.Configuration.BaseDelayMs;
-            int jitteredBackoff = history.Configuration.Jitter(history.Retries, expoBackoff, new Random(JitterSeed));
+            int jitteredBackoff = history.Configuration.Jitter(history.Retries, expoBackoff, history.Random);
             return new Retry(expoBackoff, jitteredBackoff);
         }
 


### PR DESCRIPTION
This is so that clients do not use the the same seed when calculating jitter during retry/backoff.