### PR TITLE
Tom/socket closed detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ set to `true` by default in order to allow the server to detect replay attacks.
 - Removed obsolete client methods that accept a `CancellationTokenSource`. These have been replaced in favor
 of methods that accept a `CancellationToken` that were added in v3.3.
 
+### Fixed
+- Fix an issue with Socket Closed event taking a significant length of time or not firing at all when internet connection is lost
 
 ## [3.4.0] - 2022-04-28
 ### Added

--- a/Nakama.Tests/Socket/WebSocketTest.cs
+++ b/Nakama.Tests/Socket/WebSocketTest.cs
@@ -111,5 +111,24 @@ namespace Nakama.Tests.Socket
             Assert.True(_socket.IsConnected);
             _ = _socket.CloseAsync();
         }
+
+        [Fact(Skip = "Test requires you to disconnect the internet and wait for 60 seconds minimum")]
+        public async Task SocketDetectsLossOfInternet()
+        {
+            var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
+            await _socket.ConnectAsync(session, false, 5);
+            var closeTriggered = false;
+            
+            _socket.Closed += () =>
+            {
+                _testOutputHelper.WriteLine($"Socket was closed");
+                closeTriggered = true;
+            };
+            
+            _testOutputHelper.WriteLine("---Disconnect Internet Now---");
+            await Task.Delay(TimeSpan.FromSeconds(60));
+            Assert.False(_socket.IsConnected);
+            Assert.True(closeTriggered);
+        }
     }
 }

--- a/Nakama/Ninja.WebSockets/PingPongManager.cs
+++ b/Nakama/Ninja.WebSockets/PingPongManager.cs
@@ -111,9 +111,9 @@ namespace Nakama.Ninja.WebSockets
 
                     if (_pingSentTicks != 0)
                     {
-                        await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure,
+                        await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure,
                             $"No Pong message received in response to a Ping after KeepAliveInterval {_keepAliveInterval}",
-                            _cancellationToken);
+                        _cancellationToken);
                         break;
                     }
 


### PR DESCRIPTION
There is currently an issue whereby the Web Socket's `Closed` event either doesn't fire or takes a significant length of time to do so after the internet connection is lost (i.e. fully lost, or network connection changes such as dropping from wi-fi to 4G on mobile).

Currently, the `PingPongManager` is responsible for checking the health of the connection with a heartbeat. If this heartbeat is not received after a specific period (`keepAliveInterval`), it will call `CloseAsync` on the socket. This sets the socket's state to `CloseSent` and then attempts to await sending the close message down the socket.

Unfortunately this appears to hang, sometimes indefinitely until an exception occurs, when there is no internet connection causing the socket to never report that it was closed and the `IsConnected` property remains `true`.

This PR changes the behaviour of the `PingPongManager` to use the "non-polite" `CloseOutputAsync` instead when it detects a loss of heartbeat. This instead immediately sets the state of the socket to `Closed` before sending the close message down the pipe. This results in the `Closed` event firing appropriately.