### PR TITLE
don't parse response bodies on 500 errors

### DIFF
--- a/Nakama/HttpRequestAdapter.cs
+++ b/Nakama/HttpRequestAdapter.cs
@@ -84,9 +84,17 @@ namespace Nakama
                 linkedSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken, userCancelToken.Value);
             }
 
+            var response = await _httpClient.SendAsync(request, linkedSource == null ? timeoutToken : linkedSource.Token);
+
             Logger?.InfoFormat("Send: method='{0}', uri='{1}', body='{2}'", method, uri, body);
 
-            var response = await _httpClient.SendAsync(request, linkedSource == null ? timeoutToken : linkedSource.Token);
+            if (((int)response.StatusCode) >= 500)
+            {
+                // TODO think of best way to map HTTP code to GRPC code since we can't rely
+                // on server to process it. Manually adding the mapping to SDK seems brittle.
+                throw new ApiResponseException((int) response.StatusCode, "", -1);
+            }
+
             var contents = await response.Content.ReadAsStringAsync();
             response.Content?.Dispose();
 

--- a/Nakama/HttpRequestAdapter.cs
+++ b/Nakama/HttpRequestAdapter.cs
@@ -84,10 +84,9 @@ namespace Nakama
                 linkedSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken, userCancelToken.Value);
             }
 
-            var response = await _httpClient.SendAsync(request, linkedSource == null ? timeoutToken : linkedSource.Token);
-
             Logger?.InfoFormat("Send: method='{0}', uri='{1}', body='{2}'", method, uri, body);
 
+            var response = await _httpClient.SendAsync(request, linkedSource == null ? timeoutToken : linkedSource.Token);
             if (((int)response.StatusCode) >= 500)
             {
                 // TODO think of best way to map HTTP code to GRPC code since we can't rely

--- a/Nakama/HttpRequestAdapter.cs
+++ b/Nakama/HttpRequestAdapter.cs
@@ -87,15 +87,16 @@ namespace Nakama
             Logger?.InfoFormat("Send: method='{0}', uri='{1}', body='{2}'", method, uri, body);
 
             var response = await _httpClient.SendAsync(request, linkedSource == null ? timeoutToken : linkedSource.Token);
+
+            var contents = await response.Content.ReadAsStringAsync();
+            response.Content?.Dispose();
+
             if (((int)response.StatusCode) >= 500)
             {
                 // TODO think of best way to map HTTP code to GRPC code since we can't rely
                 // on server to process it. Manually adding the mapping to SDK seems brittle.
-                throw new ApiResponseException((int) response.StatusCode, "", -1);
+                throw new ApiResponseException((int) response.StatusCode, contents, -1);
             }
-
-            var contents = await response.Content.ReadAsStringAsync();
-            response.Content?.Dispose();
 
             Logger?.InfoFormat("Received: status={0}, contents='{1}'", response.StatusCode, contents);
 


### PR DESCRIPTION
Load balancers can return HTML on 500s which breaks the existing client that expects a JSON body.

Change incoming for UnityWebRequestAdapter as well.

Closes https://github.com/heroiclabs/nakama-dotnet/issues/109