### PR TITLE
Revert "Fixes issue with parsing unquoted numbers as strings in TinyJ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ set to `true` by default in order to allow the server to detect replay attacks.
 of methods that accept a `CancellationToken` that were added in v3.3.
 
 ### Fixed
-- Fixed an issue with Socket Closed event taking a significant length of time or not firing at all when internet connection is lost.
 - Fixed an issue with `SocketClosed` event taking a significant length of time or not firing at all when internet connection is lost.
 - Fixed an issue that would occur when sending messages over the socket from multiple threads.
 - Fixed automatic retry seeding to be random across devices.

--- a/Nakama.Tests/TinyJsonParserTest.cs
+++ b/Nakama.Tests/TinyJsonParserTest.cs
@@ -35,43 +35,6 @@ namespace Nakama.Tests
         }
 
         [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
-        public void FromJson_JsonInput_NumberToString()
-        {
-            const string json = @"{""key"":12345}";
-            var obj = json.FromJson<Dictionary<string, string>>();
-            
-            Assert.Equal("12345", obj["key"]);
-        }
-        
-        [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
-        public void FromJson_JsonInput_SingleDigitNumberToString()
-        {
-            const string json = @"{""key"":1}";
-            var obj = json.FromJson<Dictionary<string, string>>();
-            
-            Assert.Equal("1", obj["key"]);
-        }
-
-        [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
-        public void FromJson_JsonInput_StringToString()
-        {
-            const string json = @"{""key"":""12345""}";
-            var obj = json.FromJson<Dictionary<string, string>>();
-            
-            Assert.Equal("12345", obj["key"]);
-        }
-        
-        [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
-        public void ToJson_LongToUnquotedJson()
-        {
-            var obj = new Dictionary<string, long>();
-            obj["key"] = 1234567891234;
-            var json = obj.ToJson();
-            
-            Assert.Equal("{\"key\":1234567891234}", json);
-        }
-
-        [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
         public void FromJson_JsonInput_ParsedTwice()
         {
             const string json1 = @"{""some_val"": ""val1"", ""nested"": [{""another_val"": ""val2""}]}";

--- a/Nakama/TinyJson/JsonParser.cs
+++ b/Nakama/TinyJson/JsonParser.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Nakama.TinyJson
 {
@@ -170,17 +169,9 @@ namespace Nakama.TinyJson
         {
             if (type == typeof(string))
             {
-                // Return the raw value if it is unquoted (e.g. a number)
-                if (json.Length > 0 && json[0] != '"' && json[json.Length-1] != '"')
-                {
-                    return json;
-                }
-                
                 if (json.Length <= 2)
                     return string.Empty;
-
                 var parseStringBuilder = new StringBuilder(json.Length);
-
                 for (var i = 1; i < json.Length - 1; ++i)
                 {
                     if (json[i] == '\\' && i + 1 < json.Length - 1)
@@ -197,7 +188,7 @@ namespace Nakama.TinyJson
                         {
                             uint c;
                             if (uint.TryParse(json.Substring(i + 2, 4),
-                                    System.Globalization.NumberStyles.AllowHexSpecifier, null, out c))
+                                System.Globalization.NumberStyles.AllowHexSpecifier, null, out c))
                             {
                                 parseStringBuilder.Append((char) c);
                                 i += 5;


### PR DESCRIPTION
…son, whe… (#108)"

This reverts commit 61a092f40237e76a8f0cea1ce5cd36c42f5666ac.

Another option is to handle single quotes but we can revert first to be safe.