### PR TITLE
expand group ban test

### DIFF
--- a/Nakama.Tests/GroupTest.cs
+++ b/Nakama.Tests/GroupTest.cs
@@ -225,10 +225,13 @@ namespace Nakama.Tests.Api
 
             await _client.AddGroupUsersAsync(session1, group.Id, new string[]{session2.UserId, session3.UserId});
             await _client.BanGroupUsersAsync(session1, group.Id, new []{session2.UserId, session3.UserId});
-
             var remainingMembers = await _client.ListGroupUsersAsync(session1, group.Id, state: null, limit: 100);
             Assert.Single(remainingMembers.GroupUsers);
-        }
 
+            await _client.JoinGroupAsync(session2, group.Id);
+
+            remainingMembers = await _client.ListGroupUsersAsync(session1, group.Id, state: null, limit: 100);
+            Assert.Single(remainingMembers.GroupUsers);
+        }
     }
 }

--- a/Nakama.Tests/GroupTest.cs
+++ b/Nakama.Tests/GroupTest.cs
@@ -232,6 +232,9 @@ namespace Nakama.Tests.Api
 
             remainingMembers = await _client.ListGroupUsersAsync(session1, group.Id, state: null, limit: 100);
             Assert.Single(remainingMembers.GroupUsers);
+
+            var groupList = await _client.ListUserGroupsAsync(session2, null, 100);
+            Assert.Empty(groupList.UserGroups);
         }
     }
 }


### PR DESCRIPTION
Test that number of members are still the same after a rejoin attempt from a banned user.

Test that `ListUserGroups` doesn't include the banned user's group for that user.