### PR TITLE
update satori test api key and test .net version

### DIFF
--- a/Satori.Tests/ClientTest.cs
+++ b/Satori.Tests/ClientTest.cs
@@ -21,7 +21,7 @@ namespace Satori.Tests
 {
     public class ClientTest
     {
-        private const string ApiKey = "a23d2dbc-9333-48af-90ec-9f0b8574bdf6";
+        private const string ApiKey = "bb4b2da1-71ba-429e-b5f3-36556abbf4c9";
         public const int TimeoutMilliseconds = 5000;
 
         private readonly Client _testClient =

--- a/Satori.Tests/Satori.Tests.csproj
+++ b/Satori.Tests/Satori.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net7.0</TargetFramework>
       <Nullable>enable</Nullable>
 
       <IsPackable>false</IsPackable>


### PR DESCRIPTION
Update the key to match the Go value in our sample data population, since the Satori tests are run with that prepopulated data.