### PR TITLE
Presence Merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Nakama: Added a `UpdatePresences` utility to `IMatch` and `IParty`. Use this method to maintain the presences in your matches and parties
+when an `IMatchPresenceEvent` or `IPartyPresenceEvent` is dispatched.
 
 ## [3.6.0]
 ### Added

--- a/Nakama.Tests/PresenceUtilTest.cs
+++ b/Nakama.Tests/PresenceUtilTest.cs
@@ -74,16 +74,16 @@ namespace Nakama.Tests.Socket
             Action<IMatchPresenceEvent> matchPresenceHandler = presenceEvent =>
             {
                 createdMatch.UpdatePresences(presenceEvent);
+
                 matchJoinTcs.SetResult(presenceEvent);
             };
-
 
             socket1.ReceivedMatchPresence += matchPresenceHandler;
             await socket2.JoinMatchAsync(createdMatch.Id);
             await matchJoinTcs.Task;
-
             socket1.ReceivedMatchPresence -= matchPresenceHandler;
-            Assert.Equal(2, createdMatch.Presences.Count());
+
+            Assert.Equal(1, createdMatch.Presences.Count());
 
             var matchLeaveTcs = new TaskCompletionSource<IMatchPresenceEvent>();
             socket1.ReceivedMatchPresence += presenceEvent =>
@@ -92,13 +92,11 @@ namespace Nakama.Tests.Socket
                 matchLeaveTcs.SetResult(presenceEvent);
             };
 
-            System.Console.WriteLine("leaving match");
-
             await socket2.LeaveMatchAsync(createdMatch);
             await matchLeaveTcs.Task;
 
             socket1.ReceivedMatchPresence -= matchPresenceHandler;
-            Assert.Equal(1, createdMatch.Presences.Count());
+            Assert.Equal(0, createdMatch.Presences.Count());
 
             await socket1.CloseAsync();
             await socket2.CloseAsync();

--- a/Nakama.Tests/PresenceUtilTest.cs
+++ b/Nakama.Tests/PresenceUtilTest.cs
@@ -1,0 +1,65 @@
+// Copyright 2021 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Nakama.Tests.Socket
+{
+    public class PresenceUtilTest
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly IClient _client;
+
+        public PresenceUtilTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+            _client = TestsUtil.FromSettingsFile();
+        }
+
+        [Fact(Timeout = TestsUtil.TIMEOUT_MILLISECONDS)]
+        public async Task ShouldUpdatePresencesMatch()
+        {
+            var session = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
+            var socket1 = Nakama.Socket.From(_client);
+            await socket1.ConnectAsync(session);
+
+            var createdParty = await socket1.CreatePartyAsync(true, 2);
+
+            var session2 = await _client.AuthenticateCustomAsync($"{Guid.NewGuid()}");
+            var socket2 = Nakama.Socket.From(_client);
+            await socket2.ConnectAsync(session2);
+
+            var partyPresenceEventTcs = new TaskCompletionSource<IPartyPresenceEvent>();
+
+            socket1.ReceivedPartyPresence += presenceEvent =>
+            {
+                createdParty.UpdatePresences(presenceEvent);
+                partyPresenceEventTcs.SetResult(presenceEvent);
+            };
+
+            socket2.JoinPartyAsync(createdParty.Id);
+
+            System.Console.WriteLine("waiting 2");
+            await partyPresenceEventTcs.Task;
+            System.Console.WriteLine("waiting 3");
+
+            Assert.Equal(2, createdParty.Presences.Count());
+            await socket1.CloseAsync();
+        }
+    }
+}

--- a/Nakama/IMatch.cs
+++ b/Nakama/IMatch.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -53,6 +54,11 @@ namespace Nakama
         /// The current user in this match. i.e. Yourself.
         /// </summary>
         IUserPresence Self { get; }
+
+        /// <summary>
+        /// Apply the joins and leaves from a presence event to the presences tracked by the match.
+        /// </summary>
+        void UpdatePresences(IMatchPresenceEvent presenceEvent);
     }
 
     /// <inheritdoc cref="IMatch"/>
@@ -77,6 +83,16 @@ namespace Nakama
             var presences = string.Join(", ", Presences);
             return
                 $"Match(Authoritative={Authoritative}, Id='{Id}', Label='{Label}', Presences=[{presences}], Size={Size}, Self={Self})";
+        }
+
+        public void UpdatePresences(IMatchPresenceEvent presenceEvent)
+        {
+            if (presenceEvent.MatchId != Id)
+            {
+                throw new InvalidOperationException("Tried updating presences belonging to the wrong match.");
+            }
+
+            PresenceUtil.UpdatePresences(_presences, presenceEvent.Joins, presenceEvent.Leaves);
         }
     }
 }

--- a/Nakama/IMatch.cs
+++ b/Nakama/IMatch.cs
@@ -92,7 +92,7 @@ namespace Nakama
                 throw new InvalidOperationException("Tried updating presences belonging to the wrong match.");
             }
 
-            PresenceUtil.UpdatePresences(_presences, presenceEvent.Joins, presenceEvent.Leaves);
+            _presences = PresenceUtil.CopyJoinsAndLeaves(_presences, presenceEvent.Joins, presenceEvent.Leaves);
         }
     }
 }

--- a/Nakama/IParty.cs
+++ b/Nakama/IParty.cs
@@ -50,5 +50,10 @@ namespace Nakama
         /// All members currently in the party.
         /// </summary>
         IEnumerable<IUserPresence> Presences { get; }
+
+        /// <summary>
+        /// Apply the joins and leaves from a presence event to the presences tracked by the party.
+        /// </summary>
+        void UpdatePresences(IPartyPresenceEvent presenceEvent);
     }
 }

--- a/Nakama/Party.cs
+++ b/Nakama/Party.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -43,5 +44,16 @@ namespace Nakama
 
         [DataMember(Name = "presences"), Preserve]
         public List<UserPresence> PresencesField { get; set; }
+
+
+        public void UpdatePresences(IPartyPresenceEvent presenceEvent)
+        {
+            if (presenceEvent.PartyId != Id)
+            {
+                throw new InvalidOperationException("Tried updating presences belonging to the wrong party.");
+            }
+
+            PresenceUtil.UpdatePresences(PresencesField, presenceEvent.Joins, presenceEvent.Leaves);
+        }
     }
 }

--- a/Nakama/Party.cs
+++ b/Nakama/Party.cs
@@ -53,7 +53,7 @@ namespace Nakama
                 throw new InvalidOperationException("Tried updating presences belonging to the wrong party.");
             }
 
-            PresenceUtil.UpdatePresences(PresencesField, presenceEvent.Joins, presenceEvent.Leaves);
+            PresencesField = PresenceUtil.CopyJoinsAndLeaves(PresencesField, presenceEvent.Joins, presenceEvent.Leaves);
         }
     }
 }

--- a/Nakama/PresenceUtil.cs
+++ b/Nakama/PresenceUtil.cs
@@ -23,6 +23,10 @@ namespace Nakama
         /// </summary>
         public static List<UserPresence> CopyJoinsAndLeaves(List<UserPresence> currentPresences, IEnumerable<IUserPresence> joins, IEnumerable<IUserPresence> leaves)
         {
+            currentPresences = currentPresences ?? new List<UserPresence>();
+            joins = joins ?? new List<UserPresence>();
+            leaves = leaves ?? new List<UserPresence>();
+
             var newPresences = new Dictionary<string, UserPresence>();
 
             foreach (UserPresence presence in currentPresences)

--- a/Nakama/PresenceUtil.cs
+++ b/Nakama/PresenceUtil.cs
@@ -19,9 +19,9 @@ namespace Nakama
     internal static class PresenceUtil
     {
         /// <summary>
-        /// Performs an in-place update of a presence list with the joins and leaves of a presence event.
+        /// Applies joins and leaves of a presence event to a copy of the provided presence list and returns the result.
         /// </summary>
-        public static void UpdatePresences(List<UserPresence> currentPresences, IEnumerable<IUserPresence> joins, IEnumerable<IUserPresence> leaves)
+        public static List<UserPresence> CopyJoinsAndLeaves(List<UserPresence> currentPresences, IEnumerable<IUserPresence> joins, IEnumerable<IUserPresence> leaves)
         {
             var newPresences = new Dictionary<string, UserPresence>();
 
@@ -30,7 +30,7 @@ namespace Nakama
                 newPresences[presence.UserId] = presence;
             }
 
-            foreach (UserPresence join in joins)
+            foreach (IUserPresence join in joins)
             {
                 if (newPresences.ContainsKey(join.UserId))
                 {
@@ -38,7 +38,7 @@ namespace Nakama
                     continue;
                 }
 
-                newPresences.Add(join.UserId, join);
+                newPresences.Add(join.UserId, IUserPresenceToUserPresence(join));
             }
 
             foreach (IUserPresence leave in leaves)
@@ -51,6 +51,20 @@ namespace Nakama
 
                 newPresences.Remove(leave.UserId);
             }
+
+            return new List<UserPresence>(newPresences.Values);
+        }
+
+        private static UserPresence IUserPresenceToUserPresence(IUserPresence userPresence)
+        {
+            return new UserPresence
+            {
+                Persistence = userPresence.Persistence,
+                SessionId = userPresence.SessionId,
+                Status = userPresence.Status,
+                Username = userPresence.Username,
+                UserId = userPresence.UserId
+            };
         }
     }
 }

--- a/Nakama/PresenceUtil.cs
+++ b/Nakama/PresenceUtil.cs
@@ -1,0 +1,56 @@
+// Copyright 2023 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Nakama
+{
+    internal static class PresenceUtil
+    {
+        /// <summary>
+        /// Performs an in-place update of a presence list with the joins and leaves of a presence event.
+        /// </summary>
+        public static void UpdatePresences(List<UserPresence> currentPresences, IEnumerable<IUserPresence> joins, IEnumerable<IUserPresence> leaves)
+        {
+            var newPresences = new Dictionary<string, UserPresence>();
+
+            foreach (UserPresence presence in currentPresences)
+            {
+                newPresences[presence.UserId] = presence;
+            }
+
+            foreach (UserPresence join in joins)
+            {
+                if (newPresences.ContainsKey(join.UserId))
+                {
+                    // unexpected
+                    continue;
+                }
+
+                newPresences.Add(join.UserId, join);
+            }
+
+            foreach (IUserPresence leave in leaves)
+            {
+                if (!newPresences.ContainsKey(leave.UserId))
+                {
+                    // unexpected
+                    continue;
+                }
+
+                newPresences.Remove(leave.UserId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Adds ability for users to "merge" presence change events into their existing match or party, which saves some bookkeeping that would otherwise need to be done on their end.