### PR TITLE
limited scope of of retry logic to very specific 500-level codes from…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Changed
 - Nakama: Mark socket as connected before event handler is called.
+- Nakama: Limited scope of of retry logic to very specific 500-level codes from the server.
 
 ### Added
 - Nakama: Rank count is now returned with tournament record listings.

--- a/Nakama/HttpRequestAdapter.cs
+++ b/Nakama/HttpRequestAdapter.cs
@@ -146,7 +146,6 @@ namespace Nakama
             {
                 switch (apiException.StatusCode)
                 {
-                    case 500:
                     case 502:
                     case 503:
                     case 504:

--- a/Nakama/HttpRequestAdapter.cs
+++ b/Nakama/HttpRequestAdapter.cs
@@ -142,7 +142,19 @@ namespace Nakama
 
         private bool IsTransientException(Exception e)
         {
-            return (e is ApiResponseException apiException && (apiException.StatusCode >= 500 || apiException.StatusCode == -1)) || e is HttpRequestException;
+            if (e is ApiResponseException apiException)
+            {
+                switch (apiException.StatusCode)
+                {
+                    case 500:
+                    case 502:
+                    case 503:
+                    case 504:
+                        return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
… the server

The criteria under which we retry is currently too broad.

@zyro I am not sure that we want the client to automatically retry on receiving 500 (Internal Error) from Nakama. Looking through Nakama, it could certainly be a temporary database issue, but it looks like it could be more permanent issues as well. What do you think about not including 500 in the retry criteria?

- [ ] Update Unity Adapter Retry Criteria
- [ ] Decide on 500.
- [ ] New Release!