### PR TITLE
3.12.1 Release + don't try to backfill notification sender ids after username changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [3.12.1] - 2024-05-30
+### Fixed
+- Nakama: Fixed an issue where notifications from other users could appear as if they were sent by the recipient user.
+- Nakama: Fixed a potential `NullReferenceException` that could occur when passing a `null` username to `IClient.UpdateAccountAsync`.
+
 ## [3.12.0] - 2024-04-08
 ### Added
 - Satori: Added `IApiLiveEvent.Id` for accessing live event identifiers.

--- a/Nakama/Client.cs
+++ b/Nakama/Client.cs
@@ -947,14 +947,6 @@ namespace Nakama
                 () => _apiClient.ListNotificationsAsync(session.AuthToken, limit, cacheableCursor, canceller),
                 new RetryHistory(session, retryConfiguration ?? GlobalRetryConfiguration, canceller));
 
-            foreach (var notification in response.Notifications)
-            {
-                if (!session.Username.Equals(notification.SenderId) && notification is ApiNotification n)
-                {
-                    n.SenderId = session.UserId;
-                }
-            }
-
             return response;
         }
 


### PR DESCRIPTION
If a user changes their account username, their old records for tournaments, notifications etc., won't be updated to reflect the new username.

To mitigate this, upon listing records, we automatically compare the record username to the session username and if they differ, we assume it's because of a username change and correct the record username to the session username: https://github.com/heroiclabs/nakama-dotnet/pull/148 

However, for notifications, the sender id can differ from the user ID simply by being from another user. So we just don't have a way to know if the user sent it to themselves but with an older username, or if it was sent to them from another user.